### PR TITLE
OpenZFS ABI more tweaks

### DIFF
--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -99,6 +99,10 @@ public class LibZFS implements ZFSContainer {
         v = getSetting(n,abi);
         features.put(n,v);
 
+        n = "LIBZFS4J_ABI_zfs_destroy";
+        v = getSetting(n,abi);
+        features.put(n,v);
+
         LOGGER.log(Level.FINE, "libzfs4j features: "+features);
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -104,6 +104,11 @@ public class LibZFS implements ZFSContainer {
         v = getSetting(n,abi);
         features.put(n,v);
 
+        /* Here the expected tweak is "pre-nv96" for VERY old ABI */
+        n = "LIBZFS4J_ABI_zfs_snapshot";
+        v = getSetting(n,abi);
+        features.put(n,v);
+
         LOGGER.log(Level.FINE, "libzfs4j features: "+features);
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -49,6 +49,7 @@ import com.sun.jna.Pointer;
  * Entry point to ZFS functionality in Java.
  * 
  * @author Kohsuke Kawaguchi
+ * @author Jim Klimov
  */
 public class LibZFS implements ZFSContainer {
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -104,6 +104,10 @@ public class LibZFS implements ZFSContainer {
         v = getSetting(n,abi);
         features.put(n,v);
 
+        n = "LIBZFS4J_ABI_zfs_destroy_snaps";
+        v = getSetting(n,abi);
+        features.put(n,v);
+
         /* Here the expected tweak is "pre-nv96" for VERY old ABI */
         n = "LIBZFS4J_ABI_zfs_snapshot";
         v = getSetting(n,abi);

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -231,8 +231,14 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
      * {@link ErrorCode#EZFS_EXISTS}.
      */
     public void destroy() {
-        if (LIBZFS.zfs_destroy(handle,false/*?*/) != 0)
-            throw new ZFSException(library,"Failed to destroy "+getName());
+        String abi = library.getFeature("LIBZFS4J_ABI_zfs_destroy");
+        if (abi.equals("openzfs")) {
+            if (LIBZFS.zfs_destroy(handle,false/*?*/) != 0)
+                throw new ZFSException(library,"Failed to destroy "+getName());
+        } else {
+            if (LIBZFS.zfs_destroy(handle) != 0)
+                throw new ZFSException(library,"Failed to destroy "+getName());
+        }
     }
 
     /**

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -257,6 +257,31 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
         destroy();
     }
 
+    /**
+     * Destroys snapshots
+     */
+    public void destroy_snaps(String name) {
+        String abi = library.getFeature("LIBZFS4J_ABI_zfs_destroy_snaps");
+        if (abi.equals("openzfs")) {
+            if (LIBZFS.zfs_destroy_snaps(handle, name, false/*?*/) != 0)
+                throw new ZFSException(library,"Failed to destroy "+getName());
+        } else {
+            if (LIBZFS.zfs_destroy_snaps(handle, name) != 0)
+                throw new ZFSException(library,"Failed to destroy "+getName());
+        }
+    }
+
+    /**
+     * Wipes out this dataset and all its data, optionally recursively.
+     */
+    public void destroy_snaps(String name, boolean recursive) {
+        if(recursive) {
+            for (ZFSObject child : children())
+                child.destroy_snaps(name, recursive);
+        }
+        destroy_snaps(name);
+    }
+
     public synchronized void dispose() {
         if (handle != null)
             LIBZFS.zfs_close(handle);

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -46,6 +46,7 @@ import com.sun.jna.ptr.IntByReference;
  * Represents ZFS snapshot, file system, volume, or pool.
  * 
  * @author Kohsuke Kawaguchi
+ * @author Jim Klimov
  */
 public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
 

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -350,13 +350,10 @@ int zfs_destroy(zfs_handle_t handle, boolean defer);
 int zfs_destroy_snaps(zfs_handle_t handle, String name, boolean _3);
 
 int zfs_clone(zfs_handle_t handle, String name, nvlist_t _3);
-/*
- * nv96 prototype:
- * int zfs_snapshot(libzfs_handle_t lib, String fullNameWithAtSnapShot, boolean recursive, nvlist_t props);
- * pre-nv96:
- * int zfs_snapshot(libzfs_handle_t lib, String fullNameWithAtSnapShot, boolean recursive);
-*/
+/* nv96 and later prototype (so good for both "legacy" and "openzfs"): */
 int zfs_snapshot(libzfs_handle_t lib, String fullNameWithAtSnapShot, boolean recursive, nvlist_t props);
+/* pre-nv96 prototype (very old - mid-way Sun OpenSolaris lifetimes): */
+int zfs_snapshot(libzfs_handle_t lib, String fullNameWithAtSnapShot, boolean recursive);
 
 int zfs_rollback(zfs_handle_t handle1, zfs_handle_t handle2, boolean _3);
 int zfs_rename(zfs_handle_t handle, String name, boolean _3);

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -224,6 +224,11 @@ int zpool_import_props(libzfs_handle_t lib, nvlist_t config, String newname,
 /*
  * Search for pools to import
  */
+/* Note: The ABI below is in place since Sol10u8 (though there was a bool
+ * added as arg3 of zpool_find_import_cached() in Sol10u6), and the last
+ * three routines in the list are not in libzfs.h of illumos-gate in 2017
+ * while the remaining first two are marked as legacy methods.
+ */
 nvlist_t zpool_find_import(libzfs_handle_t lib, int argc, /*char ** */PointerByReference argv);
 nvlist_t zpool_find_import_cached(libzfs_handle_t lib, String cachefile, String poolname, long guid);
 nvlist_t zpool_find_import_byname(libzfs_handle_t lib, int argc, /*char ** */ PointerByReference argv, String pool);

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -340,8 +340,14 @@ int zfs_iter_snapspec(zfs_handle_t handle, zfs_iter_f callback, Pointer arg);
  */
 int zfs_create(libzfs_handle_t lib, String name, int/*zfs_type_t*/ type, nvlist_t props);
 int zfs_create_ancestors(libzfs_handle_t lib, String _2);
+
+/* The legacy (Sun/Oracle Solaris; OpenSolaris) function ABI signature: */
+int zfs_destroy(zfs_handle_t handle);
+int zfs_destroy_snaps(zfs_handle_t handle, String name);
+/* The OpenZFS function ABI signature since ~2013 (per ZoL): */
 int zfs_destroy(zfs_handle_t handle, boolean defer);
 int zfs_destroy_snaps(zfs_handle_t handle, String name, boolean _3);
+
 int zfs_clone(zfs_handle_t handle, String name, nvlist_t _3);
 /*
  * nv96 prototype:
@@ -350,7 +356,7 @@ int zfs_clone(zfs_handle_t handle, String name, nvlist_t _3);
  * int zfs_snapshot(libzfs_handle_t lib, String fullNameWithAtSnapShot, boolean recursive);
 */
 int zfs_snapshot(libzfs_handle_t lib, String fullNameWithAtSnapShot, boolean recursive, nvlist_t props);
-        
+
 int zfs_rollback(zfs_handle_t handle1, zfs_handle_t handle2, boolean _3);
 int zfs_rename(zfs_handle_t handle, String name, boolean _3);
 int zfs_promote(zfs_handle_t handle);

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -45,6 +45,7 @@ import java.util.List;
 /**
  * @author Kohsuke Kawaguchi
  * @author Leo Xu
+ * @author Jim Klimov
  */
 public interface libzfs extends Library {
     public static final libzfs LIBZFS = (libzfs) Native.loadLibrary("zfs",libzfs.class);

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -214,6 +214,10 @@ int zpool_get_errlog(zpool_handle_t pool, /*nvlist_t ** */ PointerByReference pp
 int zpool_export(zpool_handle_t pool, boolean force);
 int zpool_export_force(zpool_handle_t pool);
 int zpool_import(libzfs_handle_t lib, nvlist_t config, String newname, /*char * */  String altroot);
+/* Note: the importfaulted flag was added in 2008 so applies to both the
+ * "legacy" and "openzfs"; older versions effectively default it to FALSE.
+ * This signature is in Sun Solaris 10u8, but not yet in 10u6 though...
+ */
 int zpool_import_props(libzfs_handle_t lib, nvlist_t config, String newname,
                         nvlist_t props, BooleanByReference importfaulted);
 

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -240,7 +240,10 @@ nvlist_t zpool_find_import_activeok(libzfs_handle_t lib, int argc, /*char ** */ 
  */
 //struct zfs_cmd;
 
+/* Newer "openzfs" ABI */
 String zpool_vdev_name(libzfs_handle_t lib, zpool_handle_t pool, nvlist_t nv, BooleanByReference verbose);
+/* Legacy ABI in Sol10, SXCE... */
+String zpool_vdev_name(libzfs_handle_t lib, zpool_handle_t pool, nvlist_t nv);
 int zpool_upgrade(zpool_handle_t pool , long new_version);
 int zpool_get_history(zpool_handle_t pool, /*nvlist_t ** */ PointerByReference ppNVList);
 void zpool_set_history_str(String subcommand, int argc, String[] argv, String history_str);

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -347,7 +347,7 @@ int zfs_destroy(zfs_handle_t handle);
 int zfs_destroy_snaps(zfs_handle_t handle, String name);
 /* The OpenZFS function ABI signature since ~2013 (per ZoL): */
 int zfs_destroy(zfs_handle_t handle, boolean defer);
-int zfs_destroy_snaps(zfs_handle_t handle, String name, boolean _3);
+int zfs_destroy_snaps(zfs_handle_t handle, String name, boolean defer);
 
 int zfs_clone(zfs_handle_t handle, String name, nvlist_t _3);
 /* nv96 and later prototype (so good for both "legacy" and "openzfs"): */


### PR DESCRIPTION
Went over commits between 2013-2009 to look at ABI changes that took place in the wrapper, and either handled them with new feature code or commented why we don't do so (e.g. change was before "openzfs"/"legacy" split).

Not sure why zfs_send() and zfs_receive() code in https://github.com/kohsuke/libzfs4j/commit/494c719be432a08a9b04e7fa5186de259bcba458 is commented away - but left it this way for now...