### PR TITLE
Optional allow() and unallow()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_cache:
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
+    - $HOME/.m2/
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -113,6 +113,30 @@ public class LibZFS implements ZFSContainer {
         v = getSetting(n,abi);
         features.put(n,v);
 
+        /**
+         * This couple of functions was last seen in Sol10u6 and is gone
+         * since Sol10u8. More detailed comments in ZFSObject.java::allow()
+         * At this time we wrap the old routines and log an error if absent
+         * when called; later might find and wrap newer implementations.
+         */
+        n = "LIBZFS4J_ABI_zfs_perm_set";
+        try {
+            Function.getFunction("zfs","zfs_perm_set");
+            v = getSetting(n,"pre-sol10u8");
+        } catch (Throwable e) {
+            v = getSetting(n,null);
+        }
+        features.put(n,v);
+
+        n = "LIBZFS4J_ABI_zfs_perm_remove";
+        try {
+            Function.getFunction("zfs","zfs_perm_remove");
+            v = getSetting(n,"pre-sol10u8");
+        } catch (Throwable e) {
+            v = getSetting(n,null);
+        }
+        features.put(n,v);
+
         LOGGER.log(Level.FINE, "libzfs4j features: "+features);
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -150,6 +150,12 @@ public class LibZFS implements ZFSContainer {
         v = System.getenv(key);
         if (v!=null)    return v;
 
+        /*
+         * Avoid using `null' as the defaultValue, so that subsequent
+         * calls to stringvar.equals(...) are kept simple.
+         */
+        if (v == null)  return "NO-OP";
+
         return defaultValue;
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -154,7 +154,7 @@ public class LibZFS implements ZFSContainer {
          * Avoid using `null' as the defaultValue, so that subsequent
          * calls to stringvar.equals(...) are kept simple.
          */
-        if (v == null)  return "NO-OP";
+        if (defaultValue == null)  return "NO-OP";
 
         return defaultValue;
     }

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -503,6 +503,27 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
     }
 
     /**
+     * Grants the specified set of permissions to this dataset.
+     */
+    public void allow(ACLBuilder acl) {
+        for (PermissionBuilder b : acl.builders) {
+            if(LIBZFS.zfs_perm_set(handle,b.toNativeFormat(this))!=0)
+                throw new ZFSException(library);
+        }
+    }
+
+    /**
+     * Revokes the specified set of permissions to this dataset.
+     */
+    public void unallow(ACLBuilder acl) {
+        for (PermissionBuilder b : acl.builders) {
+            if(LIBZFS.zfs_perm_remove(handle,b.toNativeFormat(this))!=0)
+                throw new ZFSException(library);
+        }
+    }
+
+
+    /**
      * Returns {@link #getName() the name}.
      */
     @Override

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -523,7 +523,7 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
         } else {
             if (abi == null)
                 abi = "<null>";
-            LOGGER.log(Level.FINE, "libzfs4j::allow() was called while LIBZFS4J_ABI_zfs_perm_set=='"+abi+"'");
+            LOGGER.log(Level.FINE, "NO-OP: libzfs4j::allow() was called while LIBZFS4J_ABI_zfs_perm_set=='"+abi+"' and this is currently not implemented");
         }
 
     }
@@ -542,7 +542,7 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
         } else {
             if (abi == null)
                 abi = "<null>";
-            LOGGER.log(Level.FINE, "libzfs4j::unallow() was called while LIBZFS4J_ABI_zfs_perm_remove=='"+abi+"'");
+            LOGGER.log(Level.FINE, "NO-OP: libzfs4j::unallow() was called while LIBZFS4J_ABI_zfs_perm_remove=='"+abi+"' and this is currently not implemented");
         }
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -521,8 +521,6 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
                     throw new ZFSException(library);
             }
         } else {
-            if (abi == null)
-                abi = "<null>";
             LOGGER.log(Level.FINE, "NO-OP: libzfs4j::allow() was called while LIBZFS4J_ABI_zfs_perm_set=='"+abi+"' and this is currently not implemented");
         }
 
@@ -540,8 +538,6 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
                     throw new ZFSException(library);
             }
         } else {
-            if (abi == null)
-                abi = "<null>";
             LOGGER.log(Level.FINE, "NO-OP: libzfs4j::unallow() was called while LIBZFS4J_ABI_zfs_perm_remove=='"+abi+"' and this is currently not implemented");
         }
     }

--- a/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/jna/libzfs.java
@@ -449,6 +449,10 @@ int zfs_spa_version(zfs_handle_t handle, IntByReference r);
 
 /*
  * dataset permission functions.
+ * This couple of functions was last seen in Sol10u6 and is gone
+ * since Sol10u8. More detailed comments in ZFSObject.java::allow()
+ * At this time we wrap the old routines and log an error if absent
+ * when called; later might find and wrap newer implementations.
  */
 int zfs_perm_set(zfs_handle_t handle, nvlist_t perms);
 int zfs_perm_remove(zfs_handle_t handle, nvlist_t perms);

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -195,6 +195,16 @@ public class LibZFSTest extends TestCase {
         }
     }
 
+    public void testAllow() {
+        ZFSFileSystem fs = zfs.create(dataSet, ZFSFileSystem.class);
+        ACLBuilder acl = new ACLBuilder();
+        acl.everyone().with(ZFSPermission.CREATE);
+        // this fails if the permission being allowed here isn't already allowed to me
+        fs.allow(acl);
+        // for reasons beyond me, I can't unallow permissions that I just set above
+        // fs.unallow(acl);
+    }
+
     public void testInheritProperty() {
         ZFSFileSystem o  = zfs.create(dataSet, ZFSFileSystem.class);
         ZFSFileSystem o2 = zfs.create(dataSet+"/child",ZFSFileSystem.class);


### PR DESCRIPTION
Return API support of `libzfs.jar` `allow()` and `unallow()`, togglable by user via java opts or envvars, and defaulting to presence or lack of expected ABI routines in host's `libzfs.so`.
