### PR TITLE
Improve Autodetection of feature-flags (openzfs) and LibZFSTest and maven recipes, and a step towards JENKINS-41949

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ decision is made outside `libzfs.jar` codebase). It could help asking the
 wrapper whether it can represent ZFS on the host OS, rather than guessing
 by some strings the OS provides, though.
 
+At this time one can wrap calls to initialization of a `LibZFS` instance
+in caller's set-up method (rather than using a pre-initialized `static
+final` class member) and catch resulting exceptions -- this should wrap
+both absence of ZFS on the host OS (or other inability to use it) and the
+end-user's explicit request to not use the wrapper by `-DLIBZFS4J_API=off`.
+See `LibZFSTest.java` for more details.
+
 # Kudos
 
 * Kohsuke Kawaguchi

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,16 @@
               <value>rpool/kohsuke/</value>
             </property>
 -->
+
+<!-- To simplify tests on developer's private system, you can specify
+     the LIBZFS4J_* settings by uncommenting and/or adding lines like
+     the following (note that ideally auto-guesswork should succeed): -->
+<!--
+            <property>
+              <name>LIBZFS4J_ABI</name>
+              <value>openzfs</value>
+            </property>
+-->
           </systemProperties>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,19 @@
         <configuration>
           <forkMode>never</forkMode>
           <skip>true</skip><!-- can't really run tests -->
+          <systemProperties>
+<!-- Note that the effective (default) config for tests requires that the
+     current user account can manage datasets under this existing root: -->
+<!--
+            <property>
+              <name>libzfs.test.pool</name>
+              <value>rpool/kohsuke/</value>
+            </property>
+-->
+          </systemProperties>
         </configuration>
       </plugin>
+
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
               <value>openzfs</value>
             </property>
 -->
+
+            <property>
+              <name>libzfs.test.loglevel</name>
+              <value>INFO</value>
+            </property>
           </systemProperties>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.9.1</version>
-        <executions>
-           <execution>
-             <id>attach-javadocs</id>
-             <goals>
-               <goal>jar</goal>
-             </goals>
-           </execution>
-         </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
@@ -45,6 +49,19 @@
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+           <execution>
+             <id>attach-javadocs</id>
+             <goals>
+               <goal>jar</goal>
+             </goals>
+           </execution>
+         </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version>3.3</version>
         <configuration>
           <compilerArgument>
-            -Xlint:unchecked
+            -Xlint:unchecked,deprecation
           </compilerArgument>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
           </descriptorRefs>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <compilerArgument>
+            -Xlint:unchecked
+          </compilerArgument>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -222,7 +222,7 @@ public class LibZFS implements ZFSContainer {
      * Used in routines below to report if this LibZFS instance is not
      * enabled and allow a clean abortion of the corresponding call
      */
-    private boolean is_libzfs_enabled(String funcname) {
+    public boolean is_libzfs_enabled(String funcname) {
         if (!libzfs_enabled) {
             LOGGER.log(Level.INFO, "libzfs4j not enabled because: " + libzfsNotEnabledReason + ". Skipped " + funcname + "()");
         }

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -180,17 +180,21 @@ public class LibZFS implements ZFSContainer {
      */
     private String detectCurrentABI() {
         try {
+            LOGGER.log(Level.FINER, "libzfs4j autodetect: looking for spa_feature_is_enabled()");
             Function.getFunction("zfs","spa_feature_is_enabled");
             return "openzfs";
         } catch (Throwable e) {
             // fall through
         }
         try {
+            LOGGER.log(Level.FINER, "libzfs4j autodetect: looking for feature_is_supported()");
             Function.getFunction("zfs","feature_is_supported");
             return "openzfs";
         } catch (Throwable e) {
             // fall through
         }
+        LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support not detected - assuming legacy ZFS");
+
         return "legacy";
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -478,6 +478,7 @@ public class LibZFS implements ZFSContainer {
         return roots();
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends ZFSObject> List<T> children(Class<T> type) {
         if (!is_libzfs_enabled("children"))
             return null;

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -201,6 +201,16 @@ public class LibZFS implements ZFSContainer {
         return "legacy";
     }
 
+    /**
+     * Note that this constructor can throw exceptions if there are errors
+     * while initializing the native library (e.g. absent on the host OS).
+     * Similarly, it will throw if the end-user configuration explicitly
+     * requested to disable this wrapper and not use ZFS features in the
+     * calling program. Due to this, callers should not pre-initialize
+     * their `new LibZFS()` instances in class member declarations, but
+     * rather in constructors or setup methods, and check for exceptions.
+     * Or expect such exceptions in callers of classes that might use ZFS.
+     */
     public LibZFS() {
         libzfs_enabled = false;
         libzfsNotEnabledReason = "";

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -87,6 +87,10 @@ public class LibZFS implements ZFSContainer {
 
         n = "LIBZFS4J_ABI";
         v = getSetting(n,"");
+        if (v.equals("off") || v.equals("disabled") || v.equals("false")) {
+            throw new LinkageError("libzfs4j not enabled due to user-provided setting: LIBZFS4J_ABI='" + v + "'");
+        }
+
         if (v.equals("legacy") || v.equals("openzfs")) {
             /* Currently we recognize two values; later it may be more like openzfs-YYYY */
             abi = v;
@@ -194,7 +198,7 @@ public class LibZFS implements ZFSContainer {
         if (handle==null)
             throw new LinkageError("Failed to initialize libzfs");
 
-        initFeatures();
+        initFeatures(); // Can throw LinkageError if e.g. ZFS is disabled by user settings
     }
 
     /**

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -212,8 +212,10 @@ public class LibZFS implements ZFSContainer {
             initFeatures();
         }
 
-        if (!libzfsNotEnabledReason.isEmpty())
+        if (!libzfsNotEnabledReason.isEmpty()) {
+            LOGGER.log(Level.FINE, "libzfs4j autodetect: " + libzfsNotEnabledReason);
             throw new LinkageError(libzfsNotEnabledReason);
+        }
 
         libzfs_enabled = true;
     }

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -89,7 +89,7 @@ public class LibZFS implements ZFSContainer {
 
         n = "LIBZFS4J_ABI";
         v = getSetting(n,"");
-        if (v.equals("off") || v.equals("disabled") || v.equals("false") || v.equals("NO-OP")) {
+        if (v.equals("off") || v.equals("no") || v.equals("disabled") || v.equals("false") || v.equals("NO-OP")) {
             libzfsNotEnabledReason = "libzfs4j not enabled due to user-provided setting: LIBZFS4J_ABI='" + v + "'";
             features.put(n,"NO-OP");
             return;

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -87,7 +87,8 @@ public class LibZFS implements ZFSContainer {
 
         n = "LIBZFS4J_ABI";
         v = getSetting(n,"");
-        if (v.equals("off") || v.equals("disabled") || v.equals("false")) {
+        if (v.equals("off") || v.equals("disabled") || v.equals("false") || v.equals("NO-OP")) {
+            features.put(n,"NO-OP");
             throw new LinkageError("libzfs4j not enabled due to user-provided setting: LIBZFS4J_ABI='" + v + "'");
         }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -199,14 +199,15 @@ public class LibZFS implements ZFSContainer {
             try {
                 LOGGER.log(Level.FINER, "libzfs4j autodetect: looking for " + featureFunc + "()");
                 Function.getFunction("zfs",featureFunc);
+                LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support detected - assuming OpenZFS ABI");
                 return "openzfs";
             } catch (Throwable e) {
                 // fall through
                 LOGGER.log(Level.FINEST, "While looking for " + featureFunc + "() got this: " + e.toString());
             }
         }
-        LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support not detected - assuming legacy ZFS");
 
+        LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support not detected - assuming legacy ZFS ABI");
         return "legacy";
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/Main.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/Main.java
@@ -7,7 +7,13 @@ package org.jvnet.solaris.libzfs;
  */
 public class Main {
     public static void main(String[] args) {
-        LibZFS zfs = new LibZFS();
+        LibZFS zfs;
+        try {
+            zfs = new LibZFS();
+        } catch (Throwable e) {
+            System.out.println("Aborted because " + e.toString());
+            return;
+        }
         for (ZFSFileSystem fs : zfs.roots()) {
             System.out.println(fs.getName());
             for (ZFSFileSystem c : fs.children(ZFSFileSystem.class)) {

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -58,6 +58,11 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
 
     ZFSObject(final LibZFS library, final zfs_handle_t handle) {
         this.library = library;
+
+        if (!library.is_libzfs_enabled("ZFSObject")) {
+            throw new ZFSException(library);
+        }
+
         if (handle == null) {
             throw new ZFSException(library);
         }

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSPool.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSPool.java
@@ -41,6 +41,10 @@ public final class ZFSPool {
     private final String name;
 
     ZFSPool(final LibZFS parent, final zpool_handle_t handle) {
+        if (!parent.is_libzfs_enabled("ZFSPool")) {
+            throw new ZFSException(parent);
+        }
+
         this.library = parent;
         this.handle = handle;
         this.name = LIBZFS.zpool_get_name(handle);

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -39,7 +39,10 @@ import org.jvnet.solaris.libzfs.jna.zfs_prop_t;
 import org.jvnet.solaris.libzfs.jna.zpool_prop_t;
 
 /**
- * Unit test for simple App.
+ * Unit test for simple ZFS-aware App.
+ *
+ * @author Kohsuke Kawaguchi
+ * @author Jim Klimov
  */
 public class LibZFSTest extends TestCase {
 

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -188,7 +188,7 @@ public class LibZFSTest extends TestCase {
                 dataSet, fs.getName());
         assertTrue("ZFS exists doesn't report ZFS", zfs.exists(dataSet));
 
-        fs.destory();
+        fs.destroy();
 
         assertFalse("ZFS exists doesn't report ZFS as destroyed", zfs
                 .exists(dataSet));
@@ -275,13 +275,13 @@ public class LibZFSTest extends TestCase {
 
         assertTrue("ZFS exists failed for freshly created dataset", zfs
                 .exists(dataSet));
-        assertTrue("ZFS exists failed for freshly created dataset", zfs.exists(
+        assertTrue("ZFS exists failed for freshly created dataset of type FILESYSTEM", zfs.exists(
                 dataSet, ZFSType.FILESYSTEM));
 
-        fs1.destory();
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        fs1.destroy();
+        assertFalse("ZFS exists failed for freshly destroyed dataset", zfs
                 .exists(dataSet));
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        assertFalse("ZFS exists failed for freshly destroyed dataset of type FILESYSTEM", zfs
                 .exists(dataSet, ZFSType.FILESYSTEM));
 
         final ZFSObject fs2 = zfs.create(dataSet, ZFSFileSystem.class);
@@ -291,13 +291,13 @@ public class LibZFSTest extends TestCase {
 
         assertTrue("ZFS exists failed for freshly created dataset", zfs
                 .exists(dataSet));
-        assertTrue("ZFS exists failed for freshly created dataset", zfs.exists(
+        assertTrue("ZFS exists failed for freshly created dataset of type FILESYSTEM", zfs.exists(
                 dataSet, ZFSType.FILESYSTEM));
 
-        fs2.destory();
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        fs2.destroy();
+        assertFalse("ZFS exists failed for freshly destroyed dataset", zfs
                 .exists(dataSet));
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        assertFalse("ZFS exists failed for freshly destroyed dataset of type FILESYSTEM", zfs
                 .exists(dataSet, ZFSType.FILESYSTEM));
     }
 

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -47,7 +47,7 @@ public class LibZFSTest extends TestCase {
 
     private String ZFS_TEST_POOL_BASENAME;
 
-    private final LibZFS zfs = new LibZFS();
+    private LibZFS zfs = null;
 
     /**
      * The dataset name that can be created in a test.
@@ -58,8 +58,17 @@ public class LibZFSTest extends TestCase {
     public void setUp() throws Exception {
         super.setUp();
 
+        if (zfs == null) {
+            try {
+                zfs = new LibZFS();
+            } catch (Throwable e) {
+                System.out.println("Aborted " + getName() + " because: " + e.toString());
+                throw new Exception("Aborted " + getName() + " because: " + e.toString());
+            }
+        }
+
         /* allows override of zfs pool used in testing */
-       ZFS_TEST_POOL_BASENAME = System
+        ZFS_TEST_POOL_BASENAME = System
                 .getProperty(ZFS_TEST_POOL_OVERRIDE_PROPERTY,
                         ZFS_TEST_POOL_BASENAME_DEFAULT);
 


### PR DESCRIPTION
I tested recently integrated jenkins-2.55+libzfs-0.8, and on one of my systems it did not work out of the box. This PR includes results of my drilling down to the causes (ultimately - none of the two tested "feature" functions were present on this OS, but some others were) and improvements to self-testing and reporting, and Maven recipes that came along this way.

Also includes a bit of the discussed future for https://issues.jenkins-ci.org/browse/JENKINS-41949 - an option to NOT use the zfs wrapper in a particular deployment, by passing `LIBZFS4J_ABI=false` (or one of several other similar values), making it safer to enable ZFS features in Jenkins at some point without regard to "SunOS" identification - if the library handle can't be grabbed, `new LibZFS()` will throw an exception. If a say ZoL user does not want to use ZFS, he can explicitly configure the Jenkins appserver with the disable-toggle, and `new LibZFS()` will throw an exception (same type, other text in comment).

Also, if initialization of a `LibZFS()` instance did not succeed for any of these reasons, most of the class functions will bail producing `null` results, empty lists, etc. accordingly, and log a message about this.