### PR TITLE
Lockpick script to determine host OS best-match settings

### DIFF
--- a/License.CDDL
+++ b/License.CDDL
@@ -1,0 +1,377 @@
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE Version 1.0
+
+1. Definitions.
+
+    1.1. "Contributor" means each individual or entity that creates
+         or contributes to the creation of Modifications.
+
+    1.2. "Contributor Version" means the combination of the Original
+         Software, prior Modifications used by a Contributor (if any),
+         and the Modifications made by that particular Contributor.
+
+    1.3. "Covered Software" means (a) the Original Software, or (b)
+         Modifications, or (c) the combination of files containing
+         Original Software with files containing Modifications, in
+         each case including portions thereof.
+
+    1.4. "Executable" means the Covered Software in any form other
+         than Source Code.
+
+    1.5. "Initial Developer" means the individual or entity that first
+         makes Original Software available under this License.
+
+    1.6. "Larger Work" means a work which combines Covered Software or
+         portions thereof with code not governed by the terms of this
+         License.
+
+    1.7. "License" means this document.
+
+    1.8. "Licensable" means having the right to grant, to the maximum
+         extent possible, whether at the time of the initial grant or
+         subsequently acquired, any and all of the rights conveyed
+         herein.
+
+    1.9. "Modifications" means the Source Code and Executable form of
+         any of the following:
+
+        A. Any file that results from an addition to, deletion from or
+           modification of the contents of a file containing Original
+           Software or previous Modifications;
+
+        B. Any new file that contains any part of the Original
+           Software or previous Modifications; or
+
+        C. Any new file that is contributed or otherwise made
+           available under the terms of this License.
+
+    1.10. "Original Software" means the Source Code and Executable
+          form of computer software code that is originally released
+          under this License.
+
+    1.11. "Patent Claims" means any patent claim(s), now owned or
+          hereafter acquired, including without limitation, method,
+          process, and apparatus claims, in any patent Licensable by
+          grantor.
+
+    1.12. "Source Code" means (a) the common form of computer software
+          code in which modifications are made and (b) associated
+          documentation included in or with such code.
+
+    1.13. "You" (or "Your") means an individual or a legal entity
+          exercising rights under, and complying with all of the terms
+          of, this License.  For legal entities, "You" includes any
+          entity which controls, is controlled by, or is under common
+          control with You.  For purposes of this definition,
+          "control" means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by
+          contract or otherwise, or (b) ownership of more than fifty
+          percent (50%) of the outstanding shares or beneficial
+          ownership of such entity.
+
+2. License Grants.
+
+    2.1. The Initial Developer Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and
+    subject to third party intellectual property claims, the Initial
+    Developer hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or
+            trademark) Licensable by Initial Developer, to use,
+            reproduce, modify, display, perform, sublicense and
+            distribute the Original Software (or portions thereof),
+            with or without Modifications, and/or as part of a Larger
+            Work; and
+
+        (b) under Patent Claims infringed by the making, using or
+            selling of Original Software, to make, have made, use,
+            practice, sell, and offer for sale, and/or otherwise
+            dispose of the Original Software (or portions thereof).
+
+        (c) The licenses granted in Sections 2.1(a) and (b) are
+            effective on the date Initial Developer first distributes
+            or otherwise makes the Original Software available to a
+            third party under the terms of this License.
+
+        (d) Notwithstanding Section 2.1(b) above, no patent license is
+            granted: (1) for code that You delete from the Original
+            Software, or (2) for infringements caused by: (i) the
+            modification of the Original Software, or (ii) the
+            combination of the Original Software with other software
+            or devices.
+
+    2.2. Contributor Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and
+    subject to third party intellectual property claims, each
+    Contributor hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or
+            trademark) Licensable by Contributor to use, reproduce,
+            modify, display, perform, sublicense and distribute the
+            Modifications created by such Contributor (or portions
+            thereof), either on an unmodified basis, with other
+            Modifications, as Covered Software and/or as part of a
+            Larger Work; and
+
+        (b) under Patent Claims infringed by the making, using, or
+            selling of Modifications made by that Contributor either
+            alone and/or in combination with its Contributor Version
+            (or portions of such combination), to make, use, sell,
+            offer for sale, have made, and/or otherwise dispose of:
+            (1) Modifications made by that Contributor (or portions
+            thereof); and (2) the combination of Modifications made by
+            that Contributor with its Contributor Version (or portions
+            of such combination).
+
+        (c) The licenses granted in Sections 2.2(a) and 2.2(b) are
+            effective on the date Contributor first distributes or
+            otherwise makes the Modifications available to a third
+            party.
+
+        (d) Notwithstanding Section 2.2(b) above, no patent license is
+            granted: (1) for any code that Contributor has deleted
+            from the Contributor Version; (2) for infringements caused
+            by: (i) third party modifications of Contributor Version,
+            or (ii) the combination of Modifications made by that
+            Contributor with other software (except as part of the
+            Contributor Version) or other devices; or (3) under Patent
+            Claims infringed by Covered Software in the absence of
+            Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+    3.1. Availability of Source Code.
+
+    Any Covered Software that You distribute or otherwise make
+    available in Executable form must also be made available in Source
+    Code form and that Source Code form must be distributed only under
+    the terms of this License.  You must include a copy of this
+    License with every copy of the Source Code form of the Covered
+    Software You distribute or otherwise make available.  You must
+    inform recipients of any such Covered Software in Executable form
+    as to how they can obtain such Covered Software in Source Code
+    form in a reasonable manner on or through a medium customarily
+    used for software exchange.
+
+    3.2. Modifications.
+
+    The Modifications that You create or to which You contribute are
+    governed by the terms of this License.  You represent that You
+    believe Your Modifications are Your original creation(s) and/or
+    You have sufficient rights to grant the rights conveyed by this
+    License.
+
+    3.3. Required Notices.
+
+    You must include a notice in each of Your Modifications that
+    identifies You as the Contributor of the Modification.  You may
+    not remove or alter any copyright, patent or trademark notices
+    contained within the Covered Software, or any notices of licensing
+    or any descriptive text giving attribution to any Contributor or
+    the Initial Developer.
+
+    3.4. Application of Additional Terms.
+
+    You may not offer or impose any terms on any Covered Software in
+    Source Code form that alters or restricts the applicable version
+    of this License or the recipients' rights hereunder.  You may
+    choose to offer, and to charge a fee for, warranty, support,
+    indemnity or liability obligations to one or more recipients of
+    Covered Software.  However, you may do so only on Your own behalf,
+    and not on behalf of the Initial Developer or any Contributor.
+    You must make it absolutely clear that any such warranty, support,
+    indemnity or liability obligation is offered by You alone, and You
+    hereby agree to indemnify the Initial Developer and every
+    Contributor for any liability incurred by the Initial Developer or
+    such Contributor as a result of warranty, support, indemnity or
+    liability terms You offer.
+
+    3.5. Distribution of Executable Versions.
+
+    You may distribute the Executable form of the Covered Software
+    under the terms of this License or under the terms of a license of
+    Your choice, which may contain terms different from this License,
+    provided that You are in compliance with the terms of this License
+    and that the license for the Executable form does not attempt to
+    limit or alter the recipient's rights in the Source Code form from
+    the rights set forth in this License.  If You distribute the
+    Covered Software in Executable form under a different license, You
+    must make it absolutely clear that any terms which differ from
+    this License are offered by You alone, not by the Initial
+    Developer or Contributor.  You hereby agree to indemnify the
+    Initial Developer and every Contributor for any liability incurred
+    by the Initial Developer or such Contributor as a result of any
+    such terms You offer.
+
+    3.6. Larger Works.
+
+    You may create a Larger Work by combining Covered Software with
+    other code not governed by the terms of this License and
+    distribute the Larger Work as a single product.  In such a case,
+    You must make sure the requirements of this License are fulfilled
+    for the Covered Software.
+
+4. Versions of the License.
+
+    4.1. New Versions.
+
+    Sun Microsystems, Inc. is the initial license steward and may
+    publish revised and/or new versions of this License from time to
+    time.  Each version will be given a distinguishing version number.
+    Except as provided in Section 4.3, no one other than the license
+    steward has the right to modify this License.
+
+    4.2. Effect of New Versions.
+
+    You may always continue to use, distribute or otherwise make the
+    Covered Software available under the terms of the version of the
+    License under which You originally received the Covered Software.
+    If the Initial Developer includes a notice in the Original
+    Software prohibiting it from being distributed or otherwise made
+    available under any subsequent version of the License, You must
+    distribute and make the Covered Software available under the terms
+    of the version of the License under which You originally received
+    the Covered Software.  Otherwise, You may also choose to use,
+    distribute or otherwise make the Covered Software available under
+    the terms of any subsequent version of the License published by
+    the license steward.
+
+    4.3. Modified Versions.
+
+    When You are an Initial Developer and You want to create a new
+    license for Your Original Software, You may create and use a
+    modified version of this License if You: (a) rename the license
+    and remove any references to the name of the license steward
+    (except to note that the license differs from this License); and
+    (b) otherwise make it clear that the license contains terms which
+    differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+    COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS"
+    BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+    SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+    PURPOSE OR NON-INFRINGING.  THE ENTIRE RISK AS TO THE QUALITY AND
+    PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU.  SHOULD ANY
+    COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+    INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY
+    NECESSARY SERVICING, REPAIR OR CORRECTION.  THIS DISCLAIMER OF
+    WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE.  NO USE OF
+    ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+    DISCLAIMER.
+
+6. TERMINATION.
+
+    6.1. This License and the rights granted hereunder will terminate
+    automatically if You fail to comply with terms herein and fail to
+    cure such breach within 30 days of becoming aware of the breach.
+    Provisions which, by their nature, must remain in effect beyond
+    the termination of this License shall survive.
+
+    6.2. If You assert a patent infringement claim (excluding
+    declaratory judgment actions) against Initial Developer or a
+    Contributor (the Initial Developer or Contributor against whom You
+    assert such claim is referred to as "Participant") alleging that
+    the Participant Software (meaning the Contributor Version where
+    the Participant is a Contributor or the Original Software where
+    the Participant is the Initial Developer) directly or indirectly
+    infringes any patent, then any and all rights granted directly or
+    indirectly to You by such Participant, the Initial Developer (if
+    the Initial Developer is not the Participant) and all Contributors
+    under Sections 2.1 and/or 2.2 of this License shall, upon 60 days
+    notice from Participant terminate prospectively and automatically
+    at the expiration of such 60 day notice period, unless if within
+    such 60 day period You withdraw Your claim with respect to the
+    Participant Software against such Participant either unilaterally
+    or pursuant to a written agreement with Participant.
+
+    6.3. In the event of termination under Sections 6.1 or 6.2 above,
+    all end user licenses that have been validly granted by You or any
+    distributor hereunder prior to termination (excluding licenses
+    granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+    UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+    (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+    INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+    COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+    LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+    CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+    LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+    STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+    COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+    INFORMED OF THE POSSIBILITY OF SUCH DAMAGES.  THIS LIMITATION OF
+    LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+    INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT
+    APPLICABLE LAW PROHIBITS SUCH LIMITATION.  SOME JURISDICTIONS DO
+    NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+    CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+    APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+    The Covered Software is a "commercial item," as that term is
+    defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial
+    computer software" (as that term is defined at 48
+    C.F.R. 252.227-7014(a)(1)) and "commercial computer software
+    documentation" as such terms are used in 48 C.F.R. 12.212
+    (Sept. 1995).  Consistent with 48 C.F.R. 12.212 and 48
+    C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all
+    U.S. Government End Users acquire Covered Software with only those
+    rights set forth herein.  This U.S. Government Rights clause is in
+    lieu of, and supersedes, any other FAR, DFAR, or other clause or
+    provision that addresses Government rights in computer software
+    under this License.
+
+9. MISCELLANEOUS.
+
+    This License represents the complete agreement concerning subject
+    matter hereof.  If any provision of this License is held to be
+    unenforceable, such provision shall be reformed only to the extent
+    necessary to make it enforceable.  This License shall be governed
+    by the law of the jurisdiction specified in a notice contained
+    within the Original Software (except to the extent applicable law,
+    if any, provides otherwise), excluding such jurisdiction's
+    conflict-of-law provisions.  Any litigation relating to this
+    License shall be subject to the jurisdiction of the courts located
+    in the jurisdiction and venue specified in a notice contained
+    within the Original Software, with the losing party responsible
+    for costs, including, without limitation, court costs and
+    reasonable attorneys' fees and expenses.  The application of the
+    United Nations Convention on Contracts for the International Sale
+    of Goods is expressly excluded.  Any law or regulation which
+    provides that the language of a contract shall be construed
+    against the drafter shall not apply to this License.  You agree
+    that You alone are responsible for compliance with the United
+    States export administration regulations (and the export control
+    laws and regulation of any other countries) when You use,
+    distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+    As between Initial Developer and the Contributors, each party is
+    responsible for claims and damages arising, directly or
+    indirectly, out of its utilization of rights under this License
+    and You agree to work with Initial Developer and Contributors to
+    distribute such responsibility on an equitable basis.  Nothing
+    herein is intended or shall be deemed to constitute any admission
+    of liability.
+
+--------------------------------------------------------------------
+
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND
+DISTRIBUTION LICENSE (CDDL)
+
+For Covered Software in this distribution, this License shall
+be governed by the laws of the State of California (excluding
+conflict-of-law provisions).
+
+Any litigation relating to this License shall be subject to the
+jurisdiction of the Federal Courts of the Northern District of
+California and the state courts of the State of California, with
+venue lying in Santa Clara County, California.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ logging level. See also the `lockpick-libzfs-abi.sh` script that tries out
 the currently known toggle options and their values, to pick the correct
 settings for an end-user's deployment.
 
+From practice, for late versions of Sun Solaris and several half a decade of
+operating systems and ZFS modules based on illumos and OpenZFS codebases,
+a likely end-user setup (e.g. in application server settings) would be:
+
+````
+LIBZFS4J_ABI=openzfs LIBZFS4J_ABI_zfs_iter_snapshots=legacy
+````
+while for illumos-based OSes with kernel since mid-2016 it would be all-new:
+````
+LIBZFS4J_ABI=openzfs
+````
+
 Note that there is more work possible in this area, such as in particular
 expanding Jenkins ZFS support to operating systems that do not identify as
 a `SunOS`, but this improvement is out of the scope for this update (the

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ here), or refer to the current Git HEAD status:
 
 Settings ultimately applied to each toggle can be seen in application server
 (or standalone Jetty app) log if you start it with a `FINE` or greater log4j
-logging level.
+logging level. See also the `lockpick-libzfs-abi.sh` script that tries out
+the currently known toggle options and their values, to pick the correct
+settings for an end-user's deployment.
 
 Note that there is more work possible in this area, such as in particular
 expanding Jenkins ZFS support to operating systems that do not identify as

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ decision is made outside `libzfs.jar` codebase). It could help asking the
 wrapper whether it can represent ZFS on the host OS, rather than guessing
 by some strings the OS provides, though.
 
+At this time one can wrap calls to initialization of a `LibZFS` instance
+in caller's set-up method (rather than using a pre-initialized `static
+final` class member) and catch resulting exceptions -- this should wrap
+both absence of ZFS on the host OS (or other inability to use it) and the
+end-user's explicit request to not use the wrapper by `-DLIBZFS4J_API=off`.
+See `LibZFSTest.java` for more details.
+
 # Kudos
 
 * Kohsuke Kawaguchi

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -1,0 +1,109 @@
+#! /usr/bin/env bash
+
+# Try to "lockpick" the settings relevant for libzfs.jar on this host OS
+# Note that the "correct answer" may change across OS updates... as well
+# as libzfs.jar evolution. Requires sources, "mvn" and JDK at this time.
+#
+# TODO: Add an option to libzfstest to run just a certain native routine.
+#
+# Copyright (C) 2017 by Jim Klimov
+
+# Bashism to allow pipes to fail not only due to last called program
+# Also, below, bash associative arrays are used
+set -o pipefail
+
+build_libzfs() {
+    echo "Building latest libzfs4j.jar and tests..."
+    mvn compile test-compile 2>/dev/null >/dev/null && echo "OK" || \
+        { RES=$?; echo "FAILED to build code" >&2; exit $RES; }
+}
+
+#LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.loglevel=FINEST"
+#LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.pool=mydatapool/mydataset"
+LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.pool=rpool"
+
+test_libzfs() (
+    echo ""
+    echo "Testing with the following settings:"
+    SETTINGS="$(set | egrep '^LIBZFS4J_.*=')"
+    echo "$SETTINGS"
+
+    RES=0
+    MAVEN_OPTS="-XX:ErrorFile=/dev/null"
+    export MAVEN_OPTS
+    OUT="$(mvn -DargLine=-XX:ErrorFile=/dev/null $LIBZFSTEST_MVN_OPTIONS $* test 2>&1)" || RES=$?
+    if [ "$VERBOSE" = yes ]; then
+        echo "$OUT"
+    else
+        echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq
+    fi
+
+    case "$RES" in
+        0|1) # Test could fail e.g. due to inaccessible datasets
+            echo "SUCCESS ($RES)"
+            return 0
+            ;;
+        134|*) # 134 = 128 + 6 = coredump on OS signal SEGABRT
+            echo "FAILED ($RES) with the settings above:" $SETTINGS >&2
+            ;;
+    esac
+    return $RES
+)
+
+test_defaults() {
+    echo "Try with default settings and an auto-guesser..."
+    for LIBZFS4J_ABI in \
+        legacy \
+        openzfs \
+        "" \
+    ; do
+        test_libzfs && exit
+    done
+}
+
+
+# Put most-probable variants first, to reduce amount of iterations
+declare -A LIBZFS_VARIANT_FUNCTIONS
+LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]=" legacy openzfs"
+#LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]="openzfs legacy"
+LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="legacy openzfs pre-nv96"
+#LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="openzfs legacy pre-nv96"
+LIBZFS_VARIANT_FUNCTIONS["zfs_destroy_snaps"]="openzfs legacy"
+LIBZFS_VARIANT_FUNCTIONS["zfs_destroy"]="openzfs legacy"
+# TODO: New ABI syntax for either major branch of ZFS has not yet been
+# figured out, so routines are sort of deprecated (NO-OPs) until then.
+# Still, to allow yet older Solarises to run well, we test the old ABI first.
+LIBZFS_VARIANT_FUNCTIONS["zfs_perm_remove"]="pre-sol10u8 NO-OP"
+LIBZFS_VARIANT_FUNCTIONS["zfs_perm_set"]="pre-sol10u8 NO-OP"
+
+#LIBZFS4J_ABI_zfs_destroy_snaps=openzfs, LIBZFS4J_ABI_zfs_iter_snapshots=openzfs, LIBZFS4J_ABI_zfs_destroy=openzfs, LIBZFS4J_ABI_zfs_perm_remove=NO-OP, LIBZFS4J_ABI_zfs_perm_set=NO-OP, LIBZFS4J_ABI_zfs_snapshot=openzfs, LIBZFS4J_ABI=openzfs
+
+##################### DO THE WORK #########################
+
+build_libzfs
+
+# Value set in looped calls below
+export LIBZFS4J_ABI
+#test_defaults
+
+# Override the default for individual variants explicitly in the loop below
+LIBZFS4J_ABI=legacy
+echo ""
+echo "Simple approach failed - begin lockpicking..."
+for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
+    echo ""
+#    echo "ZFS_FUNCNAME='$ZFS_FUNCNAME'"
+    for ZFS_VARIANT in ${LIBZFS_VARIANT_FUNCTIONS[${ZFS_FUNCNAME}]} "" ; do
+#        echo " ZFS_VARIANT='$ZFS_VARIANT'"
+        eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="${ZFS_VARIANT}"
+        eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
+        echo "Testing function variant LIBZFS4J_ABI_${ZFS_FUNCNAME}='${ZFS_VARIANT}'..."
+        test_libzfs -Dlibzfs.test.funcname="${ZFS_FUNCNAME}" -X && break
+    done
+done
+
+echo ""
+echo "Re-validating the full set of lockpicking results..."
+VERBOSE=yes test_libzfs && exit
+
+exit 1

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -19,7 +19,9 @@
 #
 
 # Bashism to allow pipes to fail not only due to last called program
-set -o pipefail
+if [ -n "${BASH_VERSION-}" ]; then
+    set -o pipefail
+fi
 
 # Abort on unhandled errors
 set -e

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -60,7 +60,10 @@ test_libzfs() (
 
     case "$RES" in
         0|1) # Test could fail e.g. due to inaccessible datasets
-            echo "SUCCESS ($RES)"
+            echo "SUCCESS (did not core-dump, returned $RES)"
+            if [ "$TEST_OK_ZERO_ONLY" = yes ]; then
+                return $RES
+            fi
             return 0
             ;;
         134|*) # 134 = 128 + 6 = coredump on OS signal SEGABRT
@@ -106,7 +109,7 @@ build_libzfs
 export LIBZFS4J_ABI
 
 echo "Test usability of Native ZFS from Java..."
-test_libzfs -Dlibzfs.test.funcname=testCouldStart -X || die $? "Does this host have libzfs.so?"
+TEST_OK_ZERO_ONLY=yes test_libzfs -Dlibzfs.test.funcname=testCouldStart -X || die $? "Does this host have libzfs.so?"
 
 #test_defaults && exit
 

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -15,6 +15,7 @@
 set -o pipefail
 
 # We do not care for these coredumps
+# But the hs_err_pid*.log files are not so easy to avoid
 ulimit -c 0
 
 die() {

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -14,6 +14,9 @@
 # Also, below, bash associative arrays are used
 set -o pipefail
 
+# We do not care for these coredumps
+ulimit -c 0
+
 die() {
     RES="$1"
     [ -n "$RES" ] && [ "$RES" -gt 0 ] && shift || RES=1

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -113,8 +113,11 @@ test_all_routines() {
 declare -A LIBZFS_VARIANT_FUNCTIONS
 LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]=" legacy openzfs"
 #LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]="openzfs legacy"
-LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="pre-nv96 legacy openzfs"
-#LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="openzfs legacy pre-nv96"
+### Do not normally test pre-nv96 early on - it fits inside newer
+### argument list and so does not cause a linking error, but can
+### potentially pass random heap garbage to the called new signature.
+###LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="pre-nv96 legacy openzfs"
+LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="openzfs legacy pre-nv96"
 LIBZFS_VARIANT_FUNCTIONS["zfs_destroy_snaps"]="openzfs legacy"
 LIBZFS_VARIANT_FUNCTIONS["zfs_destroy"]="openzfs legacy"
 # TODO: New ABI syntax for either major branch of ZFS has not yet been

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -59,12 +59,14 @@ LIBZFS_VARIANT_FUNCTIONS__zfs_perm_set="NO-OP pre-sol10u8"
 LIBZFS_VARIANT_FUNCTIONS="$(echo ${!LIBZFS_VARIANT_FUNCTIONS__*} | sed 's,LIBZFS_VARIANT_FUNCTIONS__,,g')"
 
 ### NOTE: Better just create that dataset and `zfs allow` your account to test
-### in it. Or use
-### "$(mkfile -v 16M testpool.img && zpool create testpool `pwd`/testpool.img)"
-### to create a test pool (as root)...
-###   sudo zfs allow -ld jim mount,create,share,destroy,snapshot rpool/kohsuke
-#LIBZFSTEST_DATASET="rpool/kohsuke"
-LIBZFSTEST_DATASET="missingrpool/fakedataset"
+### in it - avoids NPEs in some tests that preclude actual routines.
+### Can do this (as root):
+###   mkfile -v 16M testpool.img && zpool create testpool `pwd`/testpool.img
+### to create a test pool and set ZFS management permissisons on test dataset:
+###   sudo zfs create testpool/testdataset
+###   sudo zfs allow -ld "$USER" mount,create,share,destroy,snapshot testpool/testdataset
+LIBZFSTEST_DATASET="rpool/kohsuke"
+#LIBZFSTEST_DATASET="testrpool/testdataset"
 LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.pool=${LIBZFSTEST_DATASET}"
 LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.loglevel=FINEST"
 ### Avoid parallel test-cases inside our class - it is unreadable to debug

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -23,6 +23,44 @@ ulimit -c 0
 
 [ -n "${VERBOSITY-}" ] || VERBOSITY=quiet
 
+# Put the variants with longer argument lists or otherwise more-probable
+# to fail first (newer ABIs usually), to reduce amount of false-positive
+# identifications. In many cases, the legacy set of arguments fits inside
+# newer argument list and so does not cause a linking error, but still can
+# potentially pass random heap garbage to the actually called new function.
+# Find the options scaterred in sources (mostly ZFSObject.java).
+declare -A LIBZFS_VARIANT_FUNCTIONS
+
+LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="openzfs legacy pre-nv96"
+LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]="openzfs legacy"
+LIBZFS_VARIANT_FUNCTIONS["zfs_destroy_snaps"]="openzfs legacy"
+LIBZFS_VARIANT_FUNCTIONS["zfs_destroy"]="openzfs legacy"
+
+# TODO: New ABI syntax for either major branch of ZFS has not yet been
+# figured out, so routines are sort of deprecated (NO-OPs) until then.
+# Still, to allow yet older Solarises to run well, you can want to test
+# the old ABI first -- be sure to use TEST_OK_ZERO_ONLY=yes as well.
+# By currently more probable default we just "no-op" them, although
+# the "legacy" or "openzfs" options are also valid until implemented.
+#LIBZFS_VARIANT_FUNCTIONS["zfs_perm_remove"]="pre-sol10u8 NO-OP"
+#LIBZFS_VARIANT_FUNCTIONS["zfs_perm_set"]="pre-sol10u8 NO-OP"
+LIBZFS_VARIANT_FUNCTIONS["zfs_perm_remove"]="NO-OP pre-sol10u8"
+LIBZFS_VARIANT_FUNCTIONS["zfs_perm_set"]="NO-OP pre-sol10u8"
+
+
+### NOTE: Better just create that dataset and `zfs allow` your account to test
+### in it. Or use
+### "$(mkfile -v 16M testpool.img && zpool create testpool `pwd`/testpool.img)"
+### to create a test pool (as root)...
+###   sudo zfs allow -ld jim mount,create,share,destroy,snapshot rpool/kohsuke
+#LIBZFSTEST_DATASET="rpool/kohsuke"
+LIBZFSTEST_DATASET="missingrpool/fakedataset"
+LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.pool=${LIBZFSTEST_DATASET}"
+LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.loglevel=FINEST"
+### Avoid parallel test-cases inside our class - it is unreadable to debug
+LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dparallel=classes -DforkCount=0"
+
+
 die() {
     RES="$1"
     [ -n "$RES" ] && [ "$RES" -gt 0 ] && shift || RES=1
@@ -32,22 +70,17 @@ die() {
     exit $RES
 }
 
+report_match() {
+    SETTINGS="$(set | egrep '^LIBZFS4J_.*=')"
+    echo "MATCHED with the following settings: " $SETTINGS
+    return 0
+}
+
 build_libzfs() {
     echo "Building latest libzfs4j.jar and tests..."
     mvn compile test-compile 2>/dev/null >/dev/null && echo "OK" || \
         die $? "FAILED to build code"
 }
-
-### NOTE: Better just create that dataset and `zfs allow` your account to test
-### in it. Or use
-### "$(mkfile -v 16M testpool.img && zpool create testpool `pwd`/testpool.img)"
-### to create a test pool (as root)...
-###   sudo zfs allow -ld jim mount,create,share,destroy,snapshot rpool/kohsuke
-LIBZFSTEST_DATASET="rpool/kohsuke"
-LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.pool=${LIBZFSTEST_DATASET}"
-LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dlibzfs.test.loglevel=FINEST"
-### Avoid parallel test-cases inside our class - it is unreadable to debug
-LIBZFSTEST_MVN_OPTIONS="${LIBZFSTEST_MVN_OPTIONS-} -Dparallel=classes -DforkCount=0"
 
 test_libzfs() (
     echo ""
@@ -62,8 +95,8 @@ test_libzfs() (
     OUT="$(mvn -DargLine="${DUMPING_OPTS}" $LIBZFSTEST_MVN_OPTIONS "$@" test 2>&1)" || RES=$?
     case "$VERBOSITY" in
     high)
-        echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq
-        echo "$OUT" | egrep -v '^FINE.*LIBZFS4J|org.jvnet.solaris.libzfs.LibZFS initFeatures|^$'
+        echo "$OUT" | egrep '^FINE.*libzfs4j features.*LIBZFS4J' | uniq
+        echo "$OUT" | egrep -v '^FINE.*libzfs4j features.*LIBZFS4J|org.jvnet.solaris.libzfs.LibZFS initFeatures|^$'
         ;;
     yes)
         echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq
@@ -74,6 +107,7 @@ test_libzfs() (
 
     case "$RES" in
         0|1) # Test could fail e.g. due to inaccessible datasets
+             # or permissions. Normally we do not bail on this.
             echo "SUCCESS (did not core-dump, returned $RES)"
             if [ "$TEST_OK_ZERO_ONLY" = yes ]; then
                 return $RES
@@ -109,24 +143,38 @@ test_all_routines() {
     test_libzfs -Dlibzfs.test.funcname="${!LIBZFS_VARIANT_FUNCTIONS[*]}"
 }
 
-# Put most-probable variants first, to reduce amount of iterations
-declare -A LIBZFS_VARIANT_FUNCTIONS
-LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]=" legacy openzfs"
-#LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]="openzfs legacy"
-### Do not normally test pre-nv96 early on - it fits inside newer
-### argument list and so does not cause a linking error, but can
-### potentially pass random heap garbage to the called new signature.
-###LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="pre-nv96 legacy openzfs"
-LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="openzfs legacy pre-nv96"
-LIBZFS_VARIANT_FUNCTIONS["zfs_destroy_snaps"]="openzfs legacy"
-LIBZFS_VARIANT_FUNCTIONS["zfs_destroy"]="openzfs legacy"
-# TODO: New ABI syntax for either major branch of ZFS has not yet been
-# figured out, so routines are sort of deprecated (NO-OPs) until then.
-# Still, to allow yet older Solarises to run well, we test the old ABI first.
-LIBZFS_VARIANT_FUNCTIONS["zfs_perm_remove"]="pre-sol10u8 NO-OP"
-LIBZFS_VARIANT_FUNCTIONS["zfs_perm_set"]="pre-sol10u8 NO-OP"
 
-#LIBZFS4J_ABI_zfs_destroy_snaps=openzfs, LIBZFS4J_ABI_zfs_iter_snapshots=openzfs, LIBZFS4J_ABI_zfs_destroy=openzfs, LIBZFS4J_ABI_zfs_perm_remove=NO-OP, LIBZFS4J_ABI_zfs_perm_set=NO-OP, LIBZFS4J_ABI_zfs_snapshot=openzfs, LIBZFS4J_ABI=openzfs
+test_lockpick() {
+    # Override the default for individual variants explicitly in the loop below
+    LIBZFS4J_ABI=legacy
+    echo ""
+    echo "Simple approach failed - begin lockpicking..."
+    for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
+        eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="NO-OP"
+        eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
+    done
+
+    for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
+        echo ""
+        # Note: Empty token must be in the end - for library picking defaults,
+        # and as the fatal end of loop if nothing tried works for this system.
+        for ZFS_VARIANT in ${LIBZFS_VARIANT_FUNCTIONS[${ZFS_FUNCNAME}]} "" ; do
+            eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="${ZFS_VARIANT}"
+            eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
+            echo "Testing function variant LIBZFS4J_ABI_${ZFS_FUNCNAME}='${ZFS_VARIANT}'..."
+            test_libzfs -Dlibzfs.test.funcname="${ZFS_FUNCNAME}" -X && break
+            if [ -z "$ZFS_VARIANT" ]; then
+                die 1 "FAILED to find a working variant for $ZFS_FUNCNAME"
+            fi
+            #die 1 "After first test"
+        done
+        echo "============== Picked function variant LIBZFS4J_ABI_${ZFS_FUNCNAME}='${ZFS_VARIANT}'..."
+        #die 1 "After one loop"
+    done
+
+    # if here, we found variants for all functions
+    return 0
+}
 
 ##################### DO THE WORK #########################
 
@@ -137,34 +185,9 @@ export LIBZFS4J_ABI
 
 test_linkability
 
-#test_defaults && test_all_routines && exit
+test_defaults && test_all_routines && report_match && exit
 
-# Override the default for individual variants explicitly in the loop below
-LIBZFS4J_ABI=legacy
-echo ""
-echo "Simple approach failed - begin lockpicking..."
-for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
-    eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="NO-OP"
-    eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
-done
-
-for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
-    echo ""
-    # Note: Empty token must be in the end - for library picking defaults,
-    # and as the fatal end of loop if nothing tried works for this system.
-    for ZFS_VARIANT in ${LIBZFS_VARIANT_FUNCTIONS[${ZFS_FUNCNAME}]} "" ; do
-        eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="${ZFS_VARIANT}"
-        eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
-        echo "Testing function variant LIBZFS4J_ABI_${ZFS_FUNCNAME}='${ZFS_VARIANT}'..."
-        test_libzfs -Dlibzfs.test.funcname="${ZFS_FUNCNAME}" -X && break
-        if [ -z "$ZFS_VARIANT" ]; then
-            die 1 "FAILED to find a working variant for $ZFS_FUNCNAME"
-        fi
-        #die 1 "After first test"
-    done
-    echo "============== Picked function variant LIBZFS4J_ABI_${ZFS_FUNCNAME}='${ZFS_VARIANT}'..."
-    #die 1 "After one loop"
-done
+test_lockpick
 
 echo ""
 echo "Re-validating the full set of lockpicking results..."
@@ -174,4 +197,5 @@ echo ""
 echo "Packaging the results..."
 mvn $LIBZFSTEST_MVN_OPTIONS package || die $? "FAILED packaging"
 
+report_match
 exit 0

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -78,6 +78,12 @@ test_libzfs() (
     return $RES
 )
 
+test_linkability() {
+    echo "Test usability of Native ZFS from Java..."
+    TEST_OK_ZERO_ONLY=yes test_libzfs -Dlibzfs.test.funcname=testCouldStart -X >/dev/null 2>&1 \
+        && echo SUCCESS || die $? "Does this host have libzfs.so?"
+}
+
 test_defaults() {
     echo "Try with default settings and an auto-guesser..."
     for LIBZFS4J_ABI in \
@@ -113,9 +119,7 @@ build_libzfs
 # Value set in looped calls below
 export LIBZFS4J_ABI
 
-echo "Test usability of Native ZFS from Java..."
-TEST_OK_ZERO_ONLY=yes test_libzfs -Dlibzfs.test.funcname=testCouldStart -X || die $? "Does this host have libzfs.so?"
-
+test_linkability
 #test_defaults && exit
 
 # Override the default for individual variants explicitly in the loop below

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -59,7 +59,7 @@ test_libzfs() (
     DUMPING_OPTS="-XX:ErrorFile=/dev/null -Xmx64M"
     MAVEN_OPTS="${DUMPING_OPTS}"
     export MAVEN_OPTS
-    OUT="$(mvn -DargLine="${DUMPING_OPTS}" $LIBZFSTEST_MVN_OPTIONS $* test 2>&1)" || RES=$?
+    OUT="$(mvn -DargLine="${DUMPING_OPTS}" $LIBZFSTEST_MVN_OPTIONS "$@" test 2>&1)" || RES=$?
     case "$VERBOSITY" in
     high)
         echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -106,7 +106,7 @@ test_defaults() {
 declare -A LIBZFS_VARIANT_FUNCTIONS
 LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]=" legacy openzfs"
 #LIBZFS_VARIANT_FUNCTIONS["zfs_iter_snapshots"]="openzfs legacy"
-LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="legacy openzfs pre-nv96"
+LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="pre-nv96 legacy openzfs"
 #LIBZFS_VARIANT_FUNCTIONS["zfs_snapshot"]="openzfs legacy pre-nv96"
 LIBZFS_VARIANT_FUNCTIONS["zfs_destroy_snaps"]="openzfs legacy"
 LIBZFS_VARIANT_FUNCTIONS["zfs_destroy"]="openzfs legacy"

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -50,7 +50,7 @@ test_libzfs() (
     RES=0
     MAVEN_OPTS="-XX:ErrorFile=/dev/null -Xmx64M"
     export MAVEN_OPTS
-    OUT="$(mvn -DargLine=-XX:ErrorFile=/dev/null -Xmx64M $LIBZFSTEST_MVN_OPTIONS $* test 2>&1)" || RES=$?
+    OUT="$(mvn -DargLine='-XX:ErrorFile=/dev/null -Xmx64M' $LIBZFSTEST_MVN_OPTIONS $* test 2>&1)" || RES=$?
     if [ "$VERBOSE" = yes ]; then
         echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq
         echo "$OUT" | egrep -v '^FINE.*LIBZFS4J|org.jvnet.solaris.libzfs.LibZFS initFeatures'

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -9,6 +9,9 @@
 # TODO: Add an option to libzfstest to run just a certain native routine.
 #
 # Copyright (C) 2017 by Jim Klimov
+#
+# See also some docs:
+#  http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html
 
 # Bashism to allow pipes to fail not only due to last called program
 # Also, below, bash associative arrays are used
@@ -133,12 +136,10 @@ LIBZFS4J_ABI=legacy
 echo ""
 echo "Simple approach failed - begin lockpicking..."
 for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
-        eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="NO-OP"
-        eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
+    eval LIBZFS4J_ABI_${ZFS_FUNCNAME}="NO-OP"
+    eval export LIBZFS4J_ABI_${ZFS_FUNCNAME}
 done
 
-# See also some docs:
-#  http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html
 for ZFS_FUNCNAME in "${!LIBZFS_VARIANT_FUNCTIONS[@]}" ; do
     echo ""
     # Note: Empty token must be in the end - for library picking defaults,

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -104,6 +104,10 @@ build_libzfs
 
 # Value set in looped calls below
 export LIBZFS4J_ABI
+
+echo "Test usability of Native ZFS from Java..."
+test_libzfs -Dlibzfs.test.funcname=testCouldStart -X || die $? "Does this host have libzfs.so?"
+
 #test_defaults && exit
 
 # Override the default for individual variants explicitly in the loop below

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -104,6 +104,10 @@ test_defaults() {
     done
 }
 
+test_all_routines() {
+    echo "Re-validate specific routines"
+    test_libzfs -Dlibzfs.test.funcname="${!LIBZFS_VARIANT_FUNCTIONS[*]}"
+}
 
 # Put most-probable variants first, to reduce amount of iterations
 declare -A LIBZFS_VARIANT_FUNCTIONS
@@ -129,7 +133,8 @@ build_libzfs
 export LIBZFS4J_ABI
 
 test_linkability
-#test_defaults && exit
+
+#test_defaults && test_all_routines && exit
 
 # Override the default for individual variants explicitly in the loop below
 LIBZFS4J_ABI=legacy
@@ -160,7 +165,7 @@ done
 
 echo ""
 echo "Re-validating the full set of lockpicking results..."
-VERBOSITY=high test_libzfs || die $? "FAILED re-validation"
+VERBOSITY=high test_libzfs && VERBOSITY=high test_all_routines || die $? "FAILED re-validation"
 
 echo ""
 echo "Packaging the results..."

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -13,8 +13,6 @@
 # See also some docs:
 #  http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html
 #
-# TODO: Add an option to libzfstest to run just a certain native routine.
-#
 # Copyright (C) 2017 by Jim Klimov, on the terms of CDDL license:
 #
 # This file and its contents are supplied under the terms of the

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -56,9 +56,10 @@ test_libzfs() (
     OUT="$(mvn -DargLine="${DUMPING_OPTS}" $LIBZFSTEST_MVN_OPTIONS $* test 2>&1)" || RES=$?
     if [ "$VERBOSE" = yes ]; then
         echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq
-        echo "$OUT" | egrep -v '^FINE.*LIBZFS4J|org.jvnet.solaris.libzfs.LibZFS initFeatures'
+        echo "$OUT" | egrep -v '^FINE.*LIBZFS4J|org.jvnet.solaris.libzfs.LibZFS initFeatures|^$'
     else
         echo "$OUT" | egrep '^FINE.*LIBZFS4J' | uniq
+        echo "$OUT" | egrep 'testfunc_' | uniq
     fi
 
     case "$RES" in

--- a/lockpick-libzfs-abi.sh
+++ b/lockpick-libzfs-abi.sh
@@ -7,15 +7,23 @@
 # Note it is likely to leave around Java coredump files, or at least logs
 # of those with stack traces.
 #
-# TODO: Add an option to libzfstest to run just a certain native routine.
-#
-# Copyright (C) 2017 by Jim Klimov
-#
 # Recommended usage to track down issues:
 #  VERBOSITY=high ./lockpick-libzfs-abi.sh | tee "lock.`date +%s`.log"
 #
 # See also some docs:
 #  http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html
+#
+# TODO: Add an option to libzfstest to run just a certain native routine.
+#
+# Copyright (C) 2017 by Jim Klimov, on the terms of CDDL license:
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
 #
 
 # Bashism to allow pipes to fail not only due to last called program

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,16 @@
               <value>rpool/kohsuke/</value>
             </property>
 -->
+
+<!-- To simplify tests on developer's private system, you can specify
+     the LIBZFS4J_* settings by uncommenting and/or adding lines like
+     the following (note that ideally auto-guesswork should succeed): -->
+<!--
+            <property>
+              <name>LIBZFS4J_ABI</name>
+              <value>openzfs</value>
+            </property>
+-->
           </systemProperties>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,19 @@
         <configuration>
           <forkMode>never</forkMode>
           <skip>true</skip><!-- can't really run tests -->
+          <systemProperties>
+<!-- Note that the effective (default) config for tests requires that the
+     current user account can manage datasets under this existing root: -->
+<!--
+            <property>
+              <name>libzfs.test.pool</name>
+              <value>rpool/kohsuke/</value>
+            </property>
+-->
+          </systemProperties>
         </configuration>
       </plugin>
+
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
               <value>openzfs</value>
             </property>
 -->
+
+            <property>
+              <name>libzfs.test.loglevel</name>
+              <value>INFO</value>
+            </property>
           </systemProperties>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.9.1</version>
-        <executions>
-           <execution>
-             <id>attach-javadocs</id>
-             <goals>
-               <goal>jar</goal>
-             </goals>
-           </execution>
-         </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
@@ -45,6 +49,19 @@
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+           <execution>
+             <id>attach-javadocs</id>
+             <goals>
+               <goal>jar</goal>
+             </goals>
+           </execution>
+         </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version>3.3</version>
         <configuration>
           <compilerArgument>
-            -Xlint:unchecked
+            -Xlint:unchecked,deprecation
           </compilerArgument>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
           </descriptorRefs>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <compilerArgument>
+            -Xlint:unchecked
+          </compilerArgument>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -222,7 +222,7 @@ public class LibZFS implements ZFSContainer {
      * Used in routines below to report if this LibZFS instance is not
      * enabled and allow a clean abortion of the corresponding call
      */
-    private boolean is_libzfs_enabled(String funcname) {
+    public boolean is_libzfs_enabled(String funcname) {
         if (!libzfs_enabled) {
             LOGGER.log(Level.INFO, "libzfs4j not enabled because: " + libzfsNotEnabledReason + ". Skipped " + funcname + "()");
         }

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -180,17 +180,21 @@ public class LibZFS implements ZFSContainer {
      */
     private String detectCurrentABI() {
         try {
+            LOGGER.log(Level.FINER, "libzfs4j autodetect: looking for spa_feature_is_enabled()");
             Function.getFunction("zfs","spa_feature_is_enabled");
             return "openzfs";
         } catch (Throwable e) {
             // fall through
         }
         try {
+            LOGGER.log(Level.FINER, "libzfs4j autodetect: looking for feature_is_supported()");
             Function.getFunction("zfs","feature_is_supported");
             return "openzfs";
         } catch (Throwable e) {
             // fall through
         }
+        LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support not detected - assuming legacy ZFS");
+
         return "legacy";
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -478,6 +478,7 @@ public class LibZFS implements ZFSContainer {
         return roots();
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends ZFSObject> List<T> children(Class<T> type) {
         if (!is_libzfs_enabled("children"))
             return null;

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -201,6 +201,16 @@ public class LibZFS implements ZFSContainer {
         return "legacy";
     }
 
+    /**
+     * Note that this constructor can throw exceptions if there are errors
+     * while initializing the native library (e.g. absent on the host OS).
+     * Similarly, it will throw if the end-user configuration explicitly
+     * requested to disable this wrapper and not use ZFS features in the
+     * calling program. Due to this, callers should not pre-initialize
+     * their `new LibZFS()` instances in class member declarations, but
+     * rather in constructors or setup methods, and check for exceptions.
+     * Or expect such exceptions in callers of classes that might use ZFS.
+     */
     public LibZFS() {
         libzfs_enabled = false;
         libzfsNotEnabledReason = "";

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -126,24 +126,31 @@ public class LibZFS implements ZFSContainer {
          * since Sol10u8. More detailed comments in ZFSObject.java::allow()
          * At this time we wrap the old routines and log an error if absent
          * when called; later might find and wrap newer implementations.
+         * If the caller does set a value here, honor it even if faulty.
          */
         n = "LIBZFS4J_ABI_zfs_perm_set";
-        try {
-            Function.getFunction("zfs","zfs_perm_set");
-            v = getSetting(n,"pre-sol10u8");
-        } catch (Throwable e) {
-            LOGGER.log(Level.FINEST, "While looking for zfs_perm_set() got this: " + e.toString());
-            v = getSetting(n,null);
+        v = getSetting(n,"");
+        if (v.isEmpty()) {
+            try {
+                Function.getFunction("zfs","zfs_perm_set");
+                v = getSetting(n,"pre-sol10u8");
+            } catch (Throwable e) {
+                LOGGER.log(Level.FINEST, "While looking for zfs_perm_set() got this: " + e.toString());
+                v = getSetting(n,null);
+            }
         }
         features.put(n,v);
 
         n = "LIBZFS4J_ABI_zfs_perm_remove";
-        try {
-            Function.getFunction("zfs","zfs_perm_remove");
-            v = getSetting(n,"pre-sol10u8");
-        } catch (Throwable e) {
-            LOGGER.log(Level.FINEST, "While looking for zfs_perm_remove() got this: " + e.toString());
-            v = getSetting(n,null);
+        v = getSetting(n,"");
+        if (v.isEmpty()) {
+            try {
+                Function.getFunction("zfs","zfs_perm_remove");
+                v = getSetting(n,"pre-sol10u8");
+            } catch (Throwable e) {
+                LOGGER.log(Level.FINEST, "While looking for zfs_perm_remove() got this: " + e.toString());
+                v = getSetting(n,null);
+            }
         }
         features.put(n,v);
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -87,6 +87,10 @@ public class LibZFS implements ZFSContainer {
 
         n = "LIBZFS4J_ABI";
         v = getSetting(n,"");
+        if (v.equals("off") || v.equals("disabled") || v.equals("false")) {
+            throw new LinkageError("libzfs4j not enabled due to user-provided setting: LIBZFS4J_ABI='" + v + "'");
+        }
+
         if (v.equals("legacy") || v.equals("openzfs")) {
             /* Currently we recognize two values; later it may be more like openzfs-YYYY */
             abi = v;
@@ -194,7 +198,7 @@ public class LibZFS implements ZFSContainer {
         if (handle==null)
             throw new LinkageError("Failed to initialize libzfs");
 
-        initFeatures();
+        initFeatures(); // Can throw LinkageError if e.g. ZFS is disabled by user settings
     }
 
     /**

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -212,8 +212,10 @@ public class LibZFS implements ZFSContainer {
             initFeatures();
         }
 
-        if (!libzfsNotEnabledReason.isEmpty())
+        if (!libzfsNotEnabledReason.isEmpty()) {
+            LOGGER.log(Level.FINE, "libzfs4j autodetect: " + libzfsNotEnabledReason);
             throw new LinkageError(libzfsNotEnabledReason);
+        }
 
         libzfs_enabled = true;
     }

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -89,7 +89,7 @@ public class LibZFS implements ZFSContainer {
 
         n = "LIBZFS4J_ABI";
         v = getSetting(n,"");
-        if (v.equals("off") || v.equals("disabled") || v.equals("false") || v.equals("NO-OP")) {
+        if (v.equals("off") || v.equals("no") || v.equals("disabled") || v.equals("false") || v.equals("NO-OP")) {
             libzfsNotEnabledReason = "libzfs4j not enabled due to user-provided setting: LIBZFS4J_ABI='" + v + "'";
             features.put(n,"NO-OP");
             return;

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -87,7 +87,8 @@ public class LibZFS implements ZFSContainer {
 
         n = "LIBZFS4J_ABI";
         v = getSetting(n,"");
-        if (v.equals("off") || v.equals("disabled") || v.equals("false")) {
+        if (v.equals("off") || v.equals("disabled") || v.equals("false") || v.equals("NO-OP")) {
+            features.put(n,"NO-OP");
             throw new LinkageError("libzfs4j not enabled due to user-provided setting: LIBZFS4J_ABI='" + v + "'");
         }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -199,14 +199,15 @@ public class LibZFS implements ZFSContainer {
             try {
                 LOGGER.log(Level.FINER, "libzfs4j autodetect: looking for " + featureFunc + "()");
                 Function.getFunction("zfs",featureFunc);
+                LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support detected - assuming OpenZFS ABI");
                 return "openzfs";
             } catch (Throwable e) {
                 // fall through
                 LOGGER.log(Level.FINEST, "While looking for " + featureFunc + "() got this: " + e.toString());
             }
         }
-        LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support not detected - assuming legacy ZFS");
 
+        LOGGER.log(Level.FINER, "libzfs4j autodetect: OpenZFS feature flag support not detected - assuming legacy ZFS ABI");
         return "legacy";
     }
 

--- a/src/main/java/org/jvnet/solaris/libzfs/Main.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/Main.java
@@ -7,7 +7,13 @@ package org.jvnet.solaris.libzfs;
  */
 public class Main {
     public static void main(String[] args) {
-        LibZFS zfs = new LibZFS();
+        LibZFS zfs;
+        try {
+            zfs = new LibZFS();
+        } catch (Throwable e) {
+            System.out.println("Aborted because " + e.toString());
+            return;
+        }
         for (ZFSFileSystem fs : zfs.roots()) {
             System.out.println(fs.getName());
             for (ZFSFileSystem c : fs.children(ZFSFileSystem.class)) {

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -58,6 +58,11 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
 
     ZFSObject(final LibZFS library, final zfs_handle_t handle) {
         this.library = library;
+
+        if (!library.is_libzfs_enabled("ZFSObject")) {
+            throw new ZFSException(library);
+        }
+
         if (handle == null) {
             throw new ZFSException(library);
         }

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -218,6 +218,9 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
         } else
         if (abi.equals("pre-nv96")) {
             /* Very-very old, prehistoric signature */
+            /* Be careful to not call this signature on newer OSes though,
+             * because it is a subset of newer ABI and so does not cause a
+             * link error - but may provide random data as the last arg. */
             if (LIBZFS.zfs_snapshot(library.getHandle(), fullName, recursive) != 0) {
                 throw new ZFSException(library);
             }

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSPool.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSPool.java
@@ -41,6 +41,10 @@ public final class ZFSPool {
     private final String name;
 
     ZFSPool(final LibZFS parent, final zpool_handle_t handle) {
+        if (!parent.is_libzfs_enabled("ZFSPool")) {
+            throw new ZFSException(parent);
+        }
+
         this.library = parent;
         this.handle = handle;
         this.name = LIBZFS.zpool_get_name(handle);

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -129,16 +129,22 @@ public class LibZFSTest extends TestCase {
 
         if (ZFS_TEST_FUNCNAME.isEmpty()) {
                 dataSet = ZFS_TEST_POOL_BASENAME + "/" + getName();
+                assertFalse("Prerequisite Failed, DataSet already exists [" + dataSet+ "] ", zfs.exists(dataSet));
         } else {
                 dataSet = ZFS_TEST_POOL_BASENAME;
-                System.out.println("Will test just the following function(s): " + ZFS_TEST_FUNCNAME + "\n\tin dataset: " + dataSet);
+                System.out.println("Will test just the following function(s): " + ZFS_TEST_FUNCNAME
+                        + "\tin dataset: '" + dataSet + "' (no '" + getName() + "' attached)");
         }
-
-        assertFalse("Prerequisite Failed, DataSet already exists [" + dataSet+ "] ", zfs.exists(dataSet));
     }
 
     public void tearDown() throws Exception {
         super.tearDown();
+
+        if (!ZFS_TEST_FUNCNAME.isEmpty()) {
+            System.out.println("Quickly ending test " + getName());
+            zfs.dispose();
+            return;
+        }
 
         if (dataSet != null) {
             System.out.println("TearDown test dataset [" + dataSet + "]");

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -39,7 +39,10 @@ import org.jvnet.solaris.libzfs.jna.zfs_prop_t;
 import org.jvnet.solaris.libzfs.jna.zpool_prop_t;
 
 /**
- * Unit test for simple App.
+ * Unit test for simple ZFS-aware App.
+ *
+ * @author Kohsuke Kawaguchi
+ * @author Jim Klimov
  */
 public class LibZFSTest extends TestCase {
 

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -188,7 +188,7 @@ public class LibZFSTest extends TestCase {
                 dataSet, fs.getName());
         assertTrue("ZFS exists doesn't report ZFS", zfs.exists(dataSet));
 
-        fs.destory();
+        fs.destroy();
 
         assertFalse("ZFS exists doesn't report ZFS as destroyed", zfs
                 .exists(dataSet));
@@ -275,13 +275,13 @@ public class LibZFSTest extends TestCase {
 
         assertTrue("ZFS exists failed for freshly created dataset", zfs
                 .exists(dataSet));
-        assertTrue("ZFS exists failed for freshly created dataset", zfs.exists(
+        assertTrue("ZFS exists failed for freshly created dataset of type FILESYSTEM", zfs.exists(
                 dataSet, ZFSType.FILESYSTEM));
 
-        fs1.destory();
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        fs1.destroy();
+        assertFalse("ZFS exists failed for freshly destroyed dataset", zfs
                 .exists(dataSet));
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        assertFalse("ZFS exists failed for freshly destroyed dataset of type FILESYSTEM", zfs
                 .exists(dataSet, ZFSType.FILESYSTEM));
 
         final ZFSObject fs2 = zfs.create(dataSet, ZFSFileSystem.class);
@@ -291,13 +291,13 @@ public class LibZFSTest extends TestCase {
 
         assertTrue("ZFS exists failed for freshly created dataset", zfs
                 .exists(dataSet));
-        assertTrue("ZFS exists failed for freshly created dataset", zfs.exists(
+        assertTrue("ZFS exists failed for freshly created dataset of type FILESYSTEM", zfs.exists(
                 dataSet, ZFSType.FILESYSTEM));
 
-        fs2.destory();
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        fs2.destroy();
+        assertFalse("ZFS exists failed for freshly destroyed dataset", zfs
                 .exists(dataSet));
-        assertFalse("ZFS exists failed for freshly destory dataset", zfs
+        assertFalse("ZFS exists failed for freshly destroyed dataset of type FILESYSTEM", zfs
                 .exists(dataSet, ZFSType.FILESYSTEM));
     }
 

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -465,6 +465,7 @@ public class LibZFSTest extends TestCase {
             acl.everyone().with(ZFSPermission.CREATE);
         } catch (Exception e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
         try {
+            System.out.println("testfunc__zfs_perm_set() : starting the routine");
             fs.allow(acl);
             System.out.println("testfunc__zfs_perm_set() : passed the routine");
         } catch (Exception e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
@@ -491,6 +492,7 @@ public class LibZFSTest extends TestCase {
             acl.everyone().with(ZFSPermission.CREATE);
         } catch (Exception e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
         try {
+            System.out.println("testfunc__zfs_perm_remove() : starting the routine");
             fs.unallow(acl);
             System.out.println("testfunc__zfs_perm_remove() : passed the routine");
         } catch (Exception e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -47,7 +47,7 @@ public class LibZFSTest extends TestCase {
 
     private String ZFS_TEST_POOL_BASENAME;
 
-    private final LibZFS zfs = new LibZFS();
+    private LibZFS zfs = null;
 
     /**
      * The dataset name that can be created in a test.
@@ -58,8 +58,17 @@ public class LibZFSTest extends TestCase {
     public void setUp() throws Exception {
         super.setUp();
 
+        if (zfs == null) {
+            try {
+                zfs = new LibZFS();
+            } catch (Throwable e) {
+                System.out.println("Aborted " + getName() + " because: " + e.toString());
+                throw new Exception("Aborted " + getName() + " because: " + e.toString());
+            }
+        }
+
         /* allows override of zfs pool used in testing */
-       ZFS_TEST_POOL_BASENAME = System
+        ZFS_TEST_POOL_BASENAME = System
                 .getProperty(ZFS_TEST_POOL_OVERRIDE_PROPERTY,
                         ZFS_TEST_POOL_BASENAME_DEFAULT);
 

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -249,26 +249,26 @@ public class LibZFSTest extends TestCase {
                 .exists(dataSet));
     }
 
-    public void testfunc_Destroy() {
+    public void testfunc__zfs_destroy() {
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
 
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_destroy" + "\\b.*") )
             return;
 
-        System.out.println("testfunc_Destroy() : trying to do it...");
+        System.out.println("testfunc__zfs_destroy() : trying to do it...");
 
         ZFSObject fs = null;
         try {
             zfs.create(dataSet + "/dummy", ZFSFileSystem.class);
-        } catch (Throwable e) { System.out.println("testfunc_Destroy() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
         try {
             fs = zfs.open(dataSet + "/dummy");
-        } catch (Throwable e) { System.out.println("testfunc_Destroy() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
 
         try {
             fs.destroy();
-        } catch (Throwable e) { System.out.println("testfunc_Destroy() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
     }
 
     public void testSnapshot() {
@@ -302,7 +302,7 @@ public class LibZFSTest extends TestCase {
         /* Should not throw exceptions nor segfault */
     }
 
-    public void testfunc_CreateSnapshot() {
+    public void testfunc__zfs_snapshot() {
         /* Note: This routine is ONLY for testing the linkability of the function's ABI */
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
@@ -311,19 +311,19 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_snapshot" + "\\b.*") )
             return;
 
-        System.out.println("testfunc_CreateSnapshot() : trying to do it...");
+        System.out.println("testfunc__zfs_snapshot() : trying to do it...");
 
         ZFSObject fs = null;
         String snap = "libzfstest_" + ZFS_TEST_TIMESTAMP;
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc_CreateSnapshot() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_snapshot() : exception: " + e.toString()); }
         try {
             ZFSSnapshot o = fs.createSnapshot(snap);
-        } catch (Throwable e) { System.out.println("testfunc_CreateSnapshot() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_snapshot() : exception: " + e.toString()); }
     }
 
-    public void testfunc_IterSnapshot() {
+    public void testfunc__zfs_iter_snapshots() {
         /* Note: This routine is ONLY for testing the linkability of the function's ABI */
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
@@ -331,20 +331,20 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_iter_snapshots" + "\\b.*") )
             return;
 
-        System.out.println("testfunc_IterSnapshot() : trying to do it...");
+        System.out.println("testfunc__zfs_iter_snapshots() : trying to do it...");
 
         ZFSObject fs = null;
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc_IterSnapshot() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_iter_snapshots() : exception: " + e.toString()); }
         try {
             for (ZFSObject snapds : fs.snapshots()) {
                 String name = snapds.getName();
             }
-        } catch (Throwable e) { System.out.println("testfunc_IterSnapshot() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_iter_snapshots() : exception: " + e.toString()); }
     }
 
-    public void testfunc_DestroySnapshot() {
+    public void testfunc__zfs_destroy_snaps() {
         /* Note: This routine is ONLY for testing the linkability of the function's ABI */
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
@@ -352,16 +352,16 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_destroy_snaps" + "\\b.*") )
             return;
 
-        System.out.println("testfunc_DestroySnapshot() : trying to do it...");
+        System.out.println("testfunc__zfs_destroy_snaps() : trying to do it...");
 
         ZFSObject fs = null;
         String snap = "libzfstest_" + ZFS_TEST_TIMESTAMP;
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc_DestroySnapshot() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy_snaps() : exception: " + e.toString()); }
         try {
             fs.destroySnapshot(snap);
-        } catch (Throwable e) { System.out.println("testfunc_DestroySnapshot() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy_snaps() : exception: " + e.toString()); }
         /* Should not segfault */
     }
 
@@ -440,7 +440,7 @@ public class LibZFSTest extends TestCase {
         // fs.unallow(acl);
     }
 
-    public void testfunc_Allow() {
+    public void testfunc__zfs_perm_set() {
         /* Note: Given the presets and comments above, this routine is ONLY for testing the linkability of the function's ABI at the moment */
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
@@ -448,24 +448,24 @@ public class LibZFSTest extends TestCase {
         if (!ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_perm_set" + "\\b.*") && !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_allow" + "\\b.*") )
             return;
 
-        System.out.println("testfunc_Allow() : trying to do it...");
+        System.out.println("testfunc__zfs_perm_set() : trying to do it...");
 
         ZFSObject fs = null;
         ACLBuilder acl = null;
 
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc_Allow() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
         try {
             acl = new ACLBuilder();
             acl.everyone().with(ZFSPermission.CREATE);
-        } catch (Throwable e) { System.out.println("testfunc_Allow() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
         try {
             fs.allow(acl);
-        } catch (Throwable e) { System.out.println("testfunc_Allow() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
     }
 
-    public void testfunc_Unallow() {
+    public void testfunc__zfs_perm_remove() {
         /* Note: Given the presets and comments above, this routine is ONLY for testing the linkability of the function's ABI at the moment */
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
@@ -473,21 +473,21 @@ public class LibZFSTest extends TestCase {
         if (!ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_perm_remove" + "\\b.*") && !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_unallow" + "\\b.*") )
             return;
 
-        System.out.println("testfunc_Unallow() : trying to do it...");
+        System.out.println("testfunc__zfs_perm_remove() : trying to do it...");
 
         ZFSObject fs = null;
         ACLBuilder acl = null;
 
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc_Unallow() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
         try {
             acl = new ACLBuilder();
             acl.everyone().with(ZFSPermission.CREATE);
-        } catch (Throwable e) { System.out.println("testfunc_Unallow() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
         try {
             fs.unallow(acl);
-        } catch (Throwable e) { System.out.println("testfunc_Unallow() : exception: " + e.toString()); }
+        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
     }
 
     public void testInheritProperty() {

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -159,6 +159,11 @@ public class LibZFSTest extends TestCase {
         zfs.dispose();
     }
 
+    public void testCouldStart() {
+        assertFalse("Native ZFS library could not be loaded", zfs == null);
+        System.out.println("LibZFSTest loaded OK");
+    }
+
     public void testApp() {
         /* TODO: Real func name */
         if (!ZFS_TEST_FUNCNAME.isEmpty())

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -251,15 +251,19 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_destroy" + "\\b.*") )
             return;
 
+        System.out.println("testfunc_Destroy() : trying to do it...");
+
         ZFSObject fs = null;
         try {
-            zfs.create(dataSet + "dummy", ZFSFileSystem.class);
-        } catch (Throwable e) {}
+            zfs.create(dataSet + "/dummy", ZFSFileSystem.class);
+        } catch (Throwable e) { System.out.println("testfunc_Destroy() : exception: " + e.toString()); }
         try {
-            fs = zfs.open(dataSet + "dummy");
-        } catch (Throwable e) {}
+            fs = zfs.open(dataSet + "/dummy");
+        } catch (Throwable e) { System.out.println("testfunc_Destroy() : exception: " + e.toString()); }
 
-        fs.destroy();
+        try {
+            fs.destroy();
+        } catch (Throwable e) { System.out.println("testfunc_Destroy() : exception: " + e.toString()); }
     }
 
     public void testSnapshot() {
@@ -302,12 +306,16 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_snapshot" + "\\b.*") )
             return;
 
-        ZFSObject fs = zfs.open(dataSet);
-        assertNotNull("ZFSObject was null for DataSet [" + dataSet + "]",
-                fs);
+        System.out.println("testfunc_CreateSnapshot() : trying to do it...");
 
+        ZFSObject fs = null;
         String snap = "libzfstest_" + ZFS_TEST_TIMESTAMP;
-        ZFSSnapshot o = fs.createSnapshot(snap);
+        try {
+            fs = zfs.open(dataSet);
+        } catch (Throwable e) { System.out.println("testfunc_CreateSnapshot() : exception: " + e.toString()); }
+        try {
+            ZFSSnapshot o = fs.createSnapshot(snap);
+        } catch (Throwable e) { System.out.println("testfunc_CreateSnapshot() : exception: " + e.toString()); }
     }
 
     public void testfunc_IterSnapshot() {
@@ -318,13 +326,17 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_iter_snapshots" + "\\b.*") )
             return;
 
-        ZFSObject fs = zfs.open(dataSet);
-        assertNotNull("ZFSObject was null for DataSet [" + dataSet + "]",
-                fs);
+        System.out.println("testfunc_IterSnapshot() : trying to do it...");
 
-        for (ZFSObject snapds : fs.snapshots()) {
-            String name = snapds.getName();
-        }
+        ZFSObject fs = null;
+        try {
+            fs = zfs.open(dataSet);
+        } catch (Throwable e) { System.out.println("testfunc_IterSnapshot() : exception: " + e.toString()); }
+        try {
+            for (ZFSObject snapds : fs.snapshots()) {
+                String name = snapds.getName();
+            }
+        } catch (Throwable e) { System.out.println("testfunc_IterSnapshot() : exception: " + e.toString()); }
     }
 
     public void testfunc_DestroySnapshot() {
@@ -335,13 +347,17 @@ public class LibZFSTest extends TestCase {
         if ( !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_destroy_snaps" + "\\b.*") )
             return;
 
-        ZFSObject fs = zfs.open(dataSet);
-        assertNotNull("ZFSObject was null for DataSet [" + dataSet + "]",
-                fs);
+        System.out.println("testfunc_DestroySnapshot() : trying to do it...");
 
+        ZFSObject fs = null;
         String snap = "libzfstest_" + ZFS_TEST_TIMESTAMP;
-        fs.destroySnapshot(snap);
-        /* Should not throw exceptions nor segfault */
+        try {
+            fs = zfs.open(dataSet);
+        } catch (Throwable e) { System.out.println("testfunc_DestroySnapshot() : exception: " + e.toString()); }
+        try {
+            fs.destroySnapshot(snap);
+        } catch (Throwable e) { System.out.println("testfunc_DestroySnapshot() : exception: " + e.toString()); }
+        /* Should not segfault */
     }
 
     public void testUserProperty() {
@@ -427,17 +443,24 @@ public class LibZFSTest extends TestCase {
         if (!ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_perm_set" + "\\b.*") && !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_allow" + "\\b.*") )
             return;
 
-        ZFSObject fs = zfs.open(dataSet);
-        assertNotNull("ZFSObject was null for DataSet [" + dataSet + "]",
-                fs);
+        System.out.println("testfunc_Allow() : trying to do it...");
 
-        ACLBuilder acl = new ACLBuilder();
-        acl.everyone().with(ZFSPermission.CREATE);
+        ZFSObject fs = null;
+        ACLBuilder acl = null;
 
-        fs.allow(acl);
+        try {
+            fs = zfs.open(dataSet);
+        } catch (Throwable e) { System.out.println("testfunc_Allow() : exception: " + e.toString()); }
+        try {
+            acl = new ACLBuilder();
+            acl.everyone().with(ZFSPermission.CREATE);
+        } catch (Throwable e) { System.out.println("testfunc_Allow() : exception: " + e.toString()); }
+        try {
+            fs.allow(acl);
+        } catch (Throwable e) { System.out.println("testfunc_Allow() : exception: " + e.toString()); }
     }
 
-    public void testfun_Unallow() {
+    public void testfunc_Unallow() {
         /* Note: Given the presets and comments above, this routine is ONLY for testing the linkability of the function's ABI at the moment */
         if (ZFS_TEST_FUNCNAME.isEmpty())
             return;
@@ -445,14 +468,21 @@ public class LibZFSTest extends TestCase {
         if (!ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_perm_remove" + "\\b.*") && !ZFS_TEST_FUNCNAME.matches(".*\\b" + "zfs_unallow" + "\\b.*") )
             return;
 
-        ZFSObject fs = zfs.open(dataSet);
-        assertNotNull("ZFSObject was null for DataSet [" + dataSet + "]",
-                fs);
+        System.out.println("testfunc_Unallow() : trying to do it...");
 
-        ACLBuilder acl = new ACLBuilder();
-        acl.everyone().with(ZFSPermission.CREATE);
+        ZFSObject fs = null;
+        ACLBuilder acl = null;
 
-        fs.unallow(acl);
+        try {
+            fs = zfs.open(dataSet);
+        } catch (Throwable e) { System.out.println("testfunc_Unallow() : exception: " + e.toString()); }
+        try {
+            acl = new ACLBuilder();
+            acl.everyone().with(ZFSPermission.CREATE);
+        } catch (Throwable e) { System.out.println("testfunc_Unallow() : exception: " + e.toString()); }
+        try {
+            fs.unallow(acl);
+        } catch (Throwable e) { System.out.println("testfunc_Unallow() : exception: " + e.toString()); }
     }
 
     public void testInheritProperty() {

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -110,9 +110,10 @@ public class LibZFSTest extends TestCase {
         /* allows override of zfs pool used in testing */
         ZFS_TEST_POOL_BASENAME = System
                 .getProperty(ZFS_TEST_POOL_OVERRIDE_PROPERTY,
-                        ZFS_TEST_POOL_BASENAME_DEFAULT);
+                        ZFS_TEST_POOL_BASENAME_DEFAULT)
+                .replaceAll("/+$", "");
 
-        dataSet = ZFS_TEST_POOL_BASENAME + getName();
+        dataSet = ZFS_TEST_POOL_BASENAME + "/" + getName();
 
         assertFalse("Prerequisite Failed, DataSet already exists [" + dataSet+ "] ", zfs.exists(dataSet));
     }
@@ -220,7 +221,7 @@ public class LibZFSTest extends TestCase {
             }
         }
 
-        ZFSObject o = zfs.open("rpool/kohsuke");
+        ZFSObject o = zfs.open(ZFS_TEST_POOL_BASENAME);
         System.out.println("pool    :" + o.getName());
 
         Map<zfs_prop_t, String> zfsPoolProps = o.getZfsProperty(EnumSet.allOf(zfs_prop_t.class));

--- a/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
+++ b/src/test/java/org/jvnet/solaris/libzfs/LibZFSTest.java
@@ -90,7 +90,7 @@ public class LibZFSTest extends TestCase {
             Level level;
             try {
                 level = Level.parse(ZFS_TEST_LOGLEVEL);
-            } catch ( Throwable e ) {
+            } catch (Exception e) {
                 level = Level.FINE;
             }
             LOGGER.setLevel(level);
@@ -109,7 +109,7 @@ public class LibZFSTest extends TestCase {
             try {
                 //System.out.println("Setting up a LibZFS instance for this test run...");
                 zfs = new LibZFS();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 System.out.println("Aborted " + getName() + " because: " + e.toString());
                 throw new Exception("Aborted " + getName() + " because: " + e.toString());
             }
@@ -261,14 +261,15 @@ public class LibZFSTest extends TestCase {
         ZFSObject fs = null;
         try {
             zfs.create(dataSet + "/dummy", ZFSFileSystem.class);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
         try {
             fs = zfs.open(dataSet + "/dummy");
-        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
 
         try {
             fs.destroy();
-        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
+            System.out.println("testfunc__zfs_destroy() : passed the routine");
+        } catch (Exception e) { System.out.println("testfunc__zfs_destroy() : exception: " + e.toString()); }
     }
 
     public void testSnapshot() {
@@ -317,10 +318,11 @@ public class LibZFSTest extends TestCase {
         String snap = "libzfstest_" + ZFS_TEST_TIMESTAMP;
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_snapshot() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_snapshot() : exception: " + e.toString()); }
         try {
             ZFSSnapshot o = fs.createSnapshot(snap);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_snapshot() : exception: " + e.toString()); }
+            System.out.println("testfunc__zfs_snapshot() : passed the routine");
+        } catch (Exception e) { System.out.println("testfunc__zfs_snapshot() : exception: " + e.toString()); }
     }
 
     public void testfunc__zfs_iter_snapshots() {
@@ -336,12 +338,13 @@ public class LibZFSTest extends TestCase {
         ZFSObject fs = null;
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_iter_snapshots() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_iter_snapshots() : exception: " + e.toString()); }
         try {
             for (ZFSObject snapds : fs.snapshots()) {
                 String name = snapds.getName();
             }
-        } catch (Throwable e) { System.out.println("testfunc__zfs_iter_snapshots() : exception: " + e.toString()); }
+            System.out.println("testfunc__zfs_iter_snapshots() : passed the routine");
+        } catch (Exception e) { System.out.println("testfunc__zfs_iter_snapshots() : exception: " + e.toString()); }
     }
 
     public void testfunc__zfs_destroy_snaps() {
@@ -358,10 +361,11 @@ public class LibZFSTest extends TestCase {
         String snap = "libzfstest_" + ZFS_TEST_TIMESTAMP;
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy_snaps() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_destroy_snaps() : exception: " + e.toString()); }
         try {
             fs.destroySnapshot(snap);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_destroy_snaps() : exception: " + e.toString()); }
+            System.out.println("testfunc__zfs_destroy_snaps() : passed the routine");
+        } catch (Exception e) { System.out.println("testfunc__zfs_destroy_snaps() : exception: " + e.toString()); }
         /* Should not segfault */
     }
 
@@ -455,14 +459,15 @@ public class LibZFSTest extends TestCase {
 
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
         try {
             acl = new ACLBuilder();
             acl.everyone().with(ZFSPermission.CREATE);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
         try {
             fs.allow(acl);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
+            System.out.println("testfunc__zfs_perm_set() : passed the routine");
+        } catch (Exception e) { System.out.println("testfunc__zfs_perm_set() : exception: " + e.toString()); }
     }
 
     public void testfunc__zfs_perm_remove() {
@@ -480,14 +485,15 @@ public class LibZFSTest extends TestCase {
 
         try {
             fs = zfs.open(dataSet);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
         try {
             acl = new ACLBuilder();
             acl.everyone().with(ZFSPermission.CREATE);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
+        } catch (Exception e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
         try {
             fs.unallow(acl);
-        } catch (Throwable e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
+            System.out.println("testfunc__zfs_perm_remove() : passed the routine");
+        } catch (Exception e) { System.out.println("testfunc__zfs_perm_remove() : exception: " + e.toString()); }
     }
 
     public void testInheritProperty() {


### PR DESCRIPTION
Shell script and corresponding improvements in test code (and at least one fix and some logical improvements in main code), conspiring to run maven with the test program and different ABI toggles' settings to crash the JVM... or not - picking a "correct" setting.

Ultimately, a list of `LIBZFS4J_ABI_...` options and values is produced, for the end-user to put into their appserver setup etc. - to amend the cases when if the default guessers and/or a blunt single value applied to everyone do not work in their distro and kernel/OpenZFS version.

Notes:
* This codebase builds on top of PR #8 so until that one is merged, this would seem a big bigger than it should be.
* Due to the crashing JVMs as part of the lockpick investigation, I did not do this in Java as might be more suitable for a portable project. Still, it is sufficiently reasonable to expect a `bash` wherever we can find ZFS. Also due to this, it seems that such tests can not guess their way during a "production" start-up (e.g. as part of Jenkins), and also because calling many of those routines for testing already requires presence of ZFS datasets for them to manipulate.
* Currently this code extends and maybe abuses the `LibZFSTest` program, adding and changing a number of units in it. Maybe a separate `libzfs-lockpick-victim.jar` or somesuch would be more reasonable, to cover the tests on ability to dynamically link to host libzfs at all, and then to verify the specific routines - and just `java -jar ...` this file instead of requiring and running maven all the time. So far it was simpler and faster for development to pile the tests and similar code in one place, but now that it exists and works, it should not be hard to split them if this is deemed needed.