### PR TITLE
Problem: not easy for uninformed end-users to find cause of JVM crash

### DIFF
--- a/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/LibZFS.java
@@ -236,6 +236,7 @@ public class LibZFS implements ZFSContainer {
         if (handle==null) {
             libzfsNotEnabledReason = "Failed to initialize libzfs";
         } else {
+            LOGGER.log(Level.WARNING, "libzfs4j is used on this system. If your JVM crashes with clues pointing to Java Native Interface link errors, please read documentation at https://github.com/kohsuke/libzfs4j/ regarding setup of LIBZFS4J_ABI family of variables.");
             initFeatures();
         }
 


### PR DESCRIPTION
Solution : in LibZFS.java : leave a warning in consuming application logs about LIBZFS4J_ABI setup which may be needed if default behavior fails