### PR TITLE
Help troubleshoot the case of too many datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ At this time one can wrap calls to initialization of a `LibZFS` instance
 in caller's set-up method (rather than using a pre-initialized `static
 final` class member) and catch resulting exceptions -- this should wrap
 both absence of ZFS on the host OS (or other inability to use it) and the
-end-user's explicit request to not use the wrapper by `-DLIBZFS4J_API=off`.
+end-user's explicit request to not use the wrapper by `-DLIBZFS4J_ABI=off`.
 See `LibZFSTest.java` for more details.
 
 # Kudos

--- a/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
+++ b/src/main/java/org/jvnet/solaris/libzfs/ZFSObject.java
@@ -530,6 +530,7 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
             LOGGER.log(Level.FINE, "NO-OP: libzfs4j::" + abi_thisfunc + "() was called while " + abi_toggle + "=='" + abi + "' - skipped due to config");
         } else
         if (abi.equals("openzfs")) {
+            LOGGER.log(Level.FINE, "CALLING LIBZFS4J: libzfs4j::" + abi_thisfunc + "() was called while " + abi_toggle + "=='" + abi + "' for dataset '" + getName() + "' ...");
             LIBZFS.zfs_iter_snapshots(handle, false, new libzfs.zfs_iter_f() {
                 public int callback(zfs_handle_t handle, Pointer arg) {
                     set.add((ZFSSnapshot)ZFSObject.create(library, handle));
@@ -538,6 +539,7 @@ public abstract class ZFSObject implements Comparable<ZFSObject>, ZFSContainer {
             }, null);
         } else
         if (abi.equals("legacy")) {
+            LOGGER.log(Level.FINE, "CALLING LIBZFS4J: libzfs4j::" + abi_thisfunc + "() was called while " + abi_toggle + "=='" + abi + "' for dataset '" + getName() + "' ...");
             LIBZFS.zfs_iter_snapshots(handle, new libzfs.zfs_iter_f() {
                 public int callback(zfs_handle_t handle, Pointer arg) {
                     set.add((ZFSSnapshot)ZFSObject.create(library, handle));


### PR DESCRIPTION
My Jenkins on a laptop failed startups... investigation led to this PR.

The discovered situation was that I have about 600 datasets with automatic snapshots, over 100K of those, so iterating them takes a LOT of time and memory (and in fact did not succeed since some time ago since the list in JVM exceeds the RAM I have) and in the end the appserver dies.

Some follow-up (out of scope of this PR) would be to revise how and why Jenkins chooses the ZFS datasets to look at, e.g. shouldn't it constrain to the use-case that `$JENKINS_HOME` is a dataset (maybe with children), likewise for possible separate locations with build workspaces, backups, etc. that Jenkins would own and manage - there is no point knowing about everything (unrelated) on the host system, at least not by default.